### PR TITLE
Refactor namespaces, bump version, enforce type strictness

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -21,7 +21,7 @@
 				<element value="sift_decision_"/>
 				<element value="sift_decisions_"/>
 				<element value="wc_sift_decisions"/>
-				<element value="Sift_For_WooCommerce\Sift_For_WooCommerce"/>
+				<element value="Sift_For_WooCommerce"/>
 			</property>
 		</properties>
 	</rule>

--- a/bin/test-payment-gateway/test-payment-gateway.php
+++ b/bin/test-payment-gateway/test-payment-gateway.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare( strict_types=1 );
 /*
  * Plugin Name: Simple Test Gateway for WooCommerce
  * Description: A simple payment gateway that approves all checkouts in test mode

--- a/sift-for-woocommerce.php
+++ b/sift-for-woocommerce.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * The Team51 Plugin Scaffold bootstrap file.
+ * Sift for WooCommerce
  *
  * @since       1.0.0
  * @version     1.0.0
- * @author      WordPress.com Special Projects
+ * @author      WooCommerce
  * @license     GPL-3.0-or-later
  *
  * @noinspection    ALL
@@ -13,12 +13,12 @@
  * Plugin Name:             Sift For WooCommerce
  * Plugin URI:              https://wpspecialprojects.wordpress.com
  * Description:             A plugin to integrate WooCommerce with Sift Science Fraud Detection
- * Version:                 0.0.1-alpha
+ * Version:                 1.0.0
  * Requires at least:       6.2
  * Tested up to:            6.2
  * Requires PHP:            8.0
- * Author:                  georgestephanis
- * Author URI:              https://wpspecialprojects.wordpress.com
+ * Author:                  WooCommerce
+ * Author URI:              https://github.com/woocommerce/sift-for-woocommerce
  * License:                 GPL v3 or later
  * License URI:             https://www.gnu.org/licenses/gpl-3.0.html
  * Text Domain:             sift-for-woocommerce
@@ -55,4 +55,4 @@ require_once __DIR__ . '/vendor/autoload.php';
 
 require_once __DIR__ . '/src/sift-for-woocommerce.php';
 
-\Sift_For_WooCommerce\Sift_For_WooCommerce\Sift_For_WooCommerce::get_instance();
+\Sift_For_WooCommerce\Sift_For_WooCommerce::get_instance();

--- a/sift-for-woocommerce.php
+++ b/sift-for-woocommerce.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare( strict_types=1 );
 /**
  * Sift for WooCommerce
  *

--- a/sift-for-woocommerce.php
+++ b/sift-for-woocommerce.php
@@ -1,4 +1,4 @@
-<?php declare( strict_types=1 );
+<?php
 /**
  * Sift for WooCommerce
  *
@@ -24,6 +24,7 @@
  * Text Domain:             sift-for-woocommerce
  * Domain Path:             /languages
  **/
+declare( strict_types=1 );
 
 defined( 'ABSPATH' ) || exit;
 

--- a/src/inc/abuse-decisions-actions.php
+++ b/src/inc/abuse-decisions-actions.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Sift_For_WooCommerce\Sift_For_WooCommerce\Abuse_Decision_Actions;
+namespace Sift_For_WooCommerce\Abuse_Decision_Actions;
 
 /**
  * Unblock a user from making purchases if Sift indicates that they are no longer a fraud risk.

--- a/src/inc/abuse-decisions.php
+++ b/src/inc/abuse-decisions.php
@@ -1,9 +1,9 @@
 <?php
 
 
-namespace Sift_For_WooCommerce\Sift_For_WooCommerce\Abuse_Decisions;
+namespace Sift_For_WooCommerce\Abuse_Decisions;
 
-use function Sift_For_WooCommerce\Sift_For_WooCommerce\Abuse_Decision_Actions\{
+use function Sift_For_WooCommerce\Abuse_Decision_Actions\{
 	unblock_user_from_purchases,
 	void_and_refund_user_orders,
 	cancel_and_remove_user_subscriptions,

--- a/src/inc/abuse-decisions.php
+++ b/src/inc/abuse-decisions.php
@@ -1,5 +1,4 @@
-<?php
-
+<?php declare( strict_types=1 );
 
 namespace Sift_For_WooCommerce\Abuse_Decisions;
 

--- a/src/inc/payment-gateway.php
+++ b/src/inc/payment-gateway.php
@@ -1,6 +1,6 @@
 <?php declare( strict_types=1 );
 
-namespace Sift_For_WooCommerce\Sift_For_WooCommerce;
+namespace Sift_For_WooCommerce;
 
 /**
  * A class representing a payment gateway plugin which normalizes the payment gateway property according to expectations in the Sift API.

--- a/src/inc/payment-gateways/lib/stripe.php
+++ b/src/inc/payment-gateways/lib/stripe.php
@@ -1,6 +1,6 @@
 <?php declare( strict_types=1 );
 
-namespace Sift_For_WooCommerce\Sift_For_WooCommerce\PaymentGateways\Lib;
+namespace Sift_For_WooCommerce\PaymentGateways\Lib;
 
 /**
  * A class to share Stripe-specific logic with payment gateways that use Stripe in some way.

--- a/src/inc/payment-gateways/stripe.php
+++ b/src/inc/payment-gateways/stripe.php
@@ -1,8 +1,8 @@
 <?php declare( strict_types=1 );
 
-namespace Sift_For_WooCommerce\Sift_For_WooCommerce\PaymentGateways;
+namespace Sift_For_WooCommerce\PaymentGateways;
 
-use Sift_For_WooCommerce\Sift_For_WooCommerce\PaymentGateways\Lib\Stripe;
+use Sift_For_WooCommerce\PaymentGateways\Lib\Stripe;
 
 /**
  * Utility functions used by multiple filters when working with the woocommerce-gateway-stripe plugin.

--- a/src/inc/payment-gateways/transact.php
+++ b/src/inc/payment-gateways/transact.php
@@ -2,7 +2,7 @@
 
 add_filter( 'sift_for_woocommerce_woopayments_payment_gateway_string', fn() => '$stripe' );
 
-add_filter( 'sift_for_woocommerce_woopayments_payment_type_string', array( \Sift_For_WooCommerce\Sift_For_WooCommerce\PaymentGateways\Lib\Stripe::class, 'convert_payment_type_to_sift_payment_type' ) );
+add_filter( 'sift_for_woocommerce_woopayments_payment_type_string', array( \Sift_For_WooCommerce\PaymentGateways\Lib\Stripe::class, 'convert_payment_type_to_sift_payment_type' ) );
 
 add_filter( 'sift_for_woocommerce_woopayments_payment_method_details_from_order', fn( $value, $order ) => $order ?? $value, 10, 2 );
 

--- a/src/inc/payment-gateways/woocommerce-payments.php
+++ b/src/inc/payment-gateways/woocommerce-payments.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare( strict_types=1 );
 
 add_filter( 'sift_for_woocommerce_woocommerce_payments_payment_gateway_string', fn() => '$stripe' );
 

--- a/src/inc/payment-gateways/woocommerce-payments.php
+++ b/src/inc/payment-gateways/woocommerce-payments.php
@@ -29,7 +29,7 @@ add_filter(
 	}
 );
 
-add_filter( 'sift_for_woocommerce_woocommerce_payments_payment_type_string', array( \Sift_For_WooCommerce\Sift_For_WooCommerce\PaymentGateways\Lib\Stripe::class, 'convert_payment_type_to_sift_payment_type' ) );
+add_filter( 'sift_for_woocommerce_woocommerce_payments_payment_type_string', array( \Sift_For_WooCommerce\PaymentGateways\Lib\Stripe::class, 'convert_payment_type_to_sift_payment_type' ) );
 add_filter( 'sift_for_woocommerce_woocommerce_payments_card_last4', fn( $value, $woocommerce_payments_payment_method_details ) => $woocommerce_payments_payment_method_details['card']['last4'] ?? $value, 10, 2 );
 add_filter( 'sift_for_woocommerce_woocommerce_payments_card_bin', fn( $value, $woocommerce_payments_payment_method_details ) => $woocommerce_payments_payment_method_details['card']['iin'] ?? $value, 10, 2 );
 

--- a/src/inc/payment-method.php
+++ b/src/inc/payment-method.php
@@ -1,6 +1,6 @@
 <?php declare( strict_types=1 );
 
-namespace Sift_For_WooCommerce\Sift_For_WooCommerce;
+namespace Sift_For_WooCommerce;
 
 /**
  * A class representing a payment method according to expectations in the Sift API.

--- a/src/inc/payment-type.php
+++ b/src/inc/payment-type.php
@@ -1,6 +1,6 @@
 <?php declare( strict_types=1 );
 
-namespace Sift_For_WooCommerce\Sift_For_WooCommerce;
+namespace Sift_For_WooCommerce;
 
 /**
  * A class representing a payment type which normalizes the payment type property according to expectations in the Sift API.

--- a/src/inc/rest-api-webhooks.php
+++ b/src/inc/rest-api-webhooks.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare( strict_types=1 );
 
 namespace Sift_For_WooCommerce\Rest_Api_Webhooks;
 

--- a/src/inc/rest-api-webhooks.php
+++ b/src/inc/rest-api-webhooks.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Sift_For_WooCommerce\Sift_For_WooCommerce\Rest_Api_Webhooks;
+namespace Sift_For_WooCommerce\Rest_Api_Webhooks;
 
 /**
  * Register the routes for our webhook catchers with the REST API.

--- a/src/inc/sift-object-validator.php
+++ b/src/inc/sift-object-validator.php
@@ -1,6 +1,6 @@
 <?php declare( strict_types = 1 );
 
-namespace Sift_For_WooCommerce\Sift_For_WooCommerce\Sift;
+namespace Sift_For_WooCommerce\Sift;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/src/inc/sift-order.php
+++ b/src/inc/sift-order.php
@@ -1,6 +1,6 @@
 <?php declare( strict_types=1 );
 
-namespace Sift_For_WooCommerce\Sift_For_WooCommerce;
+namespace Sift_For_WooCommerce;
 
 /**
  * A class representing a Woo order which normalizes order-related data according to expectations in the Sift API.

--- a/src/inc/sift-property.php
+++ b/src/inc/sift-property.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Sift_For_WooCommerce\Sift_For_WooCommerce;
+namespace Sift_For_WooCommerce;
 
 /**
  * An abstract class which is the basis for a string or object representing a property as a complex data type in the Sift API.

--- a/src/inc/sift-property.php
+++ b/src/inc/sift-property.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare( strict_types=1 );
 
 namespace Sift_For_WooCommerce;
 

--- a/src/inc/tracking-js.php
+++ b/src/inc/tracking-js.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare( strict_types=1 );
 
 namespace Sift_For_WooCommerce\Tracking_Js;
 

--- a/src/inc/tracking-js.php
+++ b/src/inc/tracking-js.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Sift_For_WooCommerce\Sift_For_WooCommerce\Tracking_Js;
+namespace Sift_For_WooCommerce\Tracking_Js;
 
 /**
  * This function can run multiple times, but will only print once.

--- a/src/inc/verification-status.php
+++ b/src/inc/verification-status.php
@@ -1,6 +1,6 @@
 <?php declare( strict_types=1 );
 
-namespace Sift_For_WooCommerce\Sift_For_WooCommerce;
+namespace Sift_For_WooCommerce;
 
 /**
  * A class representing a payment type which normalizes the payment type property according to expectations in the Sift API.

--- a/src/inc/wc-settings-tab.php
+++ b/src/inc/wc-settings-tab.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare( strict_types=1 );
 
 // phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 

--- a/src/inc/wc-settings-tab.php
+++ b/src/inc/wc-settings-tab.php
@@ -2,9 +2,9 @@
 
 // phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
-namespace Sift_For_WooCommerce\Sift_For_WooCommerce\WC_Settings_Tab;
+namespace Sift_For_WooCommerce\WC_Settings_Tab;
 
-use Sift_For_WooCommerce\Sift_For_WooCommerce\Sift_For_WooCommerce;
+use Sift_For_WooCommerce\Sift_For_WooCommerce;
 
 /**
  * Filter to slip in our settings tab.

--- a/src/inc/woocommerce-actions.php
+++ b/src/inc/woocommerce-actions.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare( strict_types=1 );
 
 // phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 

--- a/src/inc/woocommerce-actions.php
+++ b/src/inc/woocommerce-actions.php
@@ -1,12 +1,12 @@
-<?php
+<?php declare(strict_types=1);
 
 // phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
-namespace Sift_For_WooCommerce\Sift_For_WooCommerce\WooCommerce_Actions;
+namespace Sift_For_WooCommerce\WooCommerce_Actions;
 
 use WC_Order_Item_Product;
-use Sift_For_WooCommerce\Sift_For_WooCommerce\Sift\SiftObjectValidator;
-use Sift_For_WooCommerce\Sift_For_WooCommerce\Sift_Order;
+use Sift_For_WooCommerce\Sift\SiftObjectValidator;
+use Sift_For_WooCommerce\Sift_Order;
 
 /**
  * Class Events
@@ -139,6 +139,10 @@ class Events {
 			'$time'          => intval( 1000 * microtime( true ) ),
 		);
 
+		if ( empty( $properties['$session_id'] ) ) {
+			unset( $properties['$session_id'] );
+		}
+
 		try {
 			SiftObjectValidator::validate_login( $properties );
 		} catch ( \Exception $e ) {
@@ -161,6 +165,10 @@ class Events {
 	 */
 	public static function login_failure( string $username, \WP_Error $error ) {
 		$attempted_user = get_user_by( 'login', $username );
+		$user_id        = null;
+		if ( is_object( $attempted_user ) ) {
+			$user_id = (string) $attempted_user->ID ?? null;
+		}
 
 		switch ( $error->get_error_code() ) {
 			case 'invalid_email':
@@ -178,7 +186,7 @@ class Events {
 				$failure_reason = null;
 		}
 		$properties = array(
-			'$user_id'      => (string) $attempted_user->ID ?? null,
+			'$user_id'      => $user_id,
 			'$login_status' => '$failure',
 			'$session_id'   => WC()->session->get_customer_unique_id(),
 			'$browser'      => self::get_client_browser(), // alternately, `$app` for details of the app if not a browser.

--- a/src/inc/woocommerce-actions.php
+++ b/src/inc/woocommerce-actions.php
@@ -531,7 +531,7 @@ class Events {
 			'$order_id'        => $order_id,
 			'$verification_phone_number'
 				=> $order->get_billing_phone(),
-			'$amount'          => self::get_transaction_micros( $order->get_total() ),
+			'$amount'          => self::get_transaction_micros( floatval( $order->get_total() ) ),
 			'$currency_code'   => get_woocommerce_currency(),
 			'$items'           => $items,
 			'$payment_methods' => self::get_order_payment_methods( $order ),
@@ -600,7 +600,7 @@ class Events {
 	public static function transaction( \WC_Order $order, string $status, string $transaction_type ) {
 		$properties = array(
 			'$user_id'            => (string) $order->get_user_id(),
-			'$amount'             => self::get_transaction_micros( $order->get_total() ), // Gotta multiply it up to give an integer.
+			'$amount'             => self::get_transaction_micros( floatval( $order->get_total() ) ), // Gotta multiply it up to give an integer.
 			'$currency_code'      => $order->get_currency(),
 			'$order_id'           => (string) $order->get_id(),
 			'$transaction_type'   => $transaction_type,

--- a/src/sift-for-woocommerce.php
+++ b/src/sift-for-woocommerce.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Sift_For_WooCommerce\Sift_For_WooCommerce;
+namespace Sift_For_WooCommerce;
 
 require_once __DIR__ . '/inc/wc-settings-tab.php';
 require_once __DIR__ . '/inc/rest-api-webhooks.php';
@@ -10,6 +10,7 @@ require_once __DIR__ . '/inc/sift-property.php';
 require_once __DIR__ . '/inc/payment-method.php';
 require_once __DIR__ . '/inc/verification-status.php';
 require_once __DIR__ . '/inc/payment-gateways/load.php';
+require_once __DIR__ . '/inc/payment-gateway.php';
 require_once __DIR__ . '/inc/sift-order.php';
 require_once __DIR__ . '/inc/sift-object-validator.php';
 require_once __DIR__ . '/inc/abuse-decisions.php';
@@ -47,7 +48,7 @@ class Sift_For_WooCommerce {
 
 		add_action( 'login_header', __NAMESPACE__ . '\Tracking_Js\print_sift_tracking_js' ); // Allow Sift tracking of login page visits.
 
-		\Sift_For_WooCommerce\Sift_For_WooCommerce\WooCommerce_Actions\Events::hooks();
+		\Sift_For_WooCommerce\WooCommerce_Actions\Events::hooks();
 	}
 
 	/**

--- a/tests/AddsItemToCartEventTest.php
+++ b/tests/AddsItemToCartEventTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare( strict_types=1 );
 /**
  * Class AddsItemToCartEventTest
  *

--- a/tests/AddsItemToCartEventTest.php
+++ b/tests/AddsItemToCartEventTest.php
@@ -9,7 +9,7 @@ require_once 'EventTest.php';
 
 // phpcs:disable Universal.Arrays.DisallowShortArraySyntax.Found, WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound
 
-use Sift_For_WooCommerce\Sift_For_WooCommerce\WooCommerce_Actions\Events;
+use Sift_For_WooCommerce\WooCommerce_Actions\Events;
 
 /**
  * Test case.

--- a/tests/AddsItemToCartEventTest.php
+++ b/tests/AddsItemToCartEventTest.php
@@ -1,9 +1,10 @@
-<?php declare( strict_types=1 );
+<?php
 /**
  * Class AddsItemToCartEventTest
  *
  * @package Sift_For_WooCommerce
  */
+declare( strict_types=1 );
 
 require_once 'EventTest.php';
 

--- a/tests/CreateAccountEventTest.php
+++ b/tests/CreateAccountEventTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare( strict_types=1 );
 /**
  * Class CreateAccountEventTest
  *

--- a/tests/CreateAccountEventTest.php
+++ b/tests/CreateAccountEventTest.php
@@ -9,7 +9,7 @@ require_once 'EventTest.php';
 
 // phpcs:disable Universal.Arrays.DisallowShortArraySyntax.Found, WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound
 
-use Sift_For_WooCommerce\Sift_For_WooCommerce\WooCommerce_Actions\Events;
+use Sift_For_WooCommerce\WooCommerce_Actions\Events;
 
 /**
  * Test case.

--- a/tests/CreateAccountEventTest.php
+++ b/tests/CreateAccountEventTest.php
@@ -1,9 +1,10 @@
-<?php declare( strict_types=1 );
+<?php
 /**
  * Class CreateAccountEventTest
  *
  * @package Sift_For_WooCommerce
  */
+declare( strict_types=1 );
 
 require_once 'EventTest.php';
 

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -1,9 +1,10 @@
-<?php declare( strict_types=1 );
+<?php
 /**
  * Class EventTest
  *
  * @package Sift_For_WooCommerce
  */
+declare( strict_types=1 );
 
 // phpcs:disable Universal.Arrays.DisallowShortArraySyntax.Found
 

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -7,7 +7,7 @@
 
 // phpcs:disable Universal.Arrays.DisallowShortArraySyntax.Found
 
-use Sift_For_WooCommerce\Sift_For_WooCommerce\WooCommerce_Actions\Events;
+use Sift_For_WooCommerce\WooCommerce_Actions\Events;
 
 /**
  * Events test case.

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare( strict_types=1 );
 /**
  * Class EventTest
  *

--- a/tests/LinkSessionToUserEventTest.php
+++ b/tests/LinkSessionToUserEventTest.php
@@ -9,7 +9,7 @@ require_once 'EventTest.php';
 
 // phpcs:disable Universal.Arrays.DisallowShortArraySyntax.Found, WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound
 
-use Sift_For_WooCommerce\Sift_For_WooCommerce\WooCommerce_Actions\Events;
+use Sift_For_WooCommerce\WooCommerce_Actions\Events;
 
 /**
  * Test case.

--- a/tests/LinkSessionToUserEventTest.php
+++ b/tests/LinkSessionToUserEventTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare( strict_types=1 );
 /**
  * Class LinkSessionToUserEventTest
  *

--- a/tests/LinkSessionToUserEventTest.php
+++ b/tests/LinkSessionToUserEventTest.php
@@ -1,9 +1,10 @@
-<?php declare( strict_types=1 );
+<?php
 /**
  * Class LinkSessionToUserEventTest
  *
  * @package Sift_For_WooCommerce
  */
+declare( strict_types=1 );
 
 require_once 'EventTest.php';
 

--- a/tests/LoginEventTest.php
+++ b/tests/LoginEventTest.php
@@ -9,7 +9,7 @@ require_once 'EventTest.php';
 
 // phpcs:disable Universal.Arrays.DisallowShortArraySyntax.Found, WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound
 
-use Sift_For_WooCommerce\Sift_For_WooCommerce\WooCommerce_Actions\Events;
+use Sift_For_WooCommerce\WooCommerce_Actions\Events;
 
 /**
  * Test case.

--- a/tests/LoginEventTest.php
+++ b/tests/LoginEventTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare( strict_types=1 );
 /**
  * Class LoginEventTest
  *

--- a/tests/LoginEventTest.php
+++ b/tests/LoginEventTest.php
@@ -1,9 +1,10 @@
-<?php declare( strict_types=1 );
+<?php
 /**
  * Class LoginEventTest
  *
  * @package Sift_For_WooCommerce
  */
+declare( strict_types=1 );
 
 require_once 'EventTest.php';
 

--- a/tests/OrderStatusEventTest.php
+++ b/tests/OrderStatusEventTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare( strict_types=1 );
 /**
  * Class OrderStatusEventTest
  *

--- a/tests/OrderStatusEventTest.php
+++ b/tests/OrderStatusEventTest.php
@@ -9,7 +9,7 @@ require_once 'EventTest.php';
 
 // phpcs:disable Universal.Arrays.DisallowShortArraySyntax.Found, WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound
 
-use Sift_For_WooCommerce\Sift_For_WooCommerce\WooCommerce_Actions\Events;
+use Sift_For_WooCommerce\WooCommerce_Actions\Events;
 
 /**
  * Test case.

--- a/tests/OrderStatusEventTest.php
+++ b/tests/OrderStatusEventTest.php
@@ -1,9 +1,10 @@
-<?php declare( strict_types=1 );
+<?php
 /**
  * Class OrderStatusEventTest
  *
  * @package Sift_For_WooCommerce
  */
+declare( strict_types=1 );
 
 require_once 'EventTest.php';
 

--- a/tests/PaymentGatewayTest.php
+++ b/tests/PaymentGatewayTest.php
@@ -1,7 +1,8 @@
-<?php declare( strict_types=1 );
+<?php
 /**
  * Class PaymentGatewayTest
  */
+declare( strict_types=1 );
 
 use Sift_For_WooCommerce\Payment_Gateway;
 

--- a/tests/PaymentGatewayTest.php
+++ b/tests/PaymentGatewayTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare( strict_types=1 );
 /**
  * Class PaymentGatewayTest
  */

--- a/tests/PaymentGatewayTest.php
+++ b/tests/PaymentGatewayTest.php
@@ -3,7 +3,7 @@
  * Class PaymentGatewayTest
  */
 
-use Sift_For_WooCommerce\Sift_For_WooCommerce\Payment_Gateway;
+use Sift_For_WooCommerce\Payment_Gateway;
 
 require_once __DIR__ . '/../src/inc/payment-gateway.php';
 require_once __DIR__ . '/../src/inc/payment-gateways/index.php';

--- a/tests/PaymentMethodTest.php
+++ b/tests/PaymentMethodTest.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare( strict_types=1 );
 
 namespace Sift_For_WooCommerce\Tests;
 

--- a/tests/PaymentMethodTest.php
+++ b/tests/PaymentMethodTest.php
@@ -1,12 +1,12 @@
 <?php declare(strict_types=1);
 
-namespace Sift_For_WooCommerce\Sift_For_WooCommerce\Tests;
+namespace Sift_For_WooCommerce\Tests;
 
-use Sift_For_WooCommerce\Sift_For_WooCommerce\Payment_Gateway;
-use Sift_For_WooCommerce\Sift_For_WooCommerce\Payment_Method;
-use Sift_For_WooCommerce\Sift_For_WooCommerce\Tests\Mocks\WC_Payments_API_Charge;
+use Sift_For_WooCommerce\Payment_Gateway;
+use Sift_For_WooCommerce\Payment_Method;
+use Sift_For_WooCommerce\Tests\Mocks\WC_Payments_API_Charge;
 
-use function Sift_For_WooCommerce\Sift_For_WooCommerce\Tests\Mocks\Utils\build_mock_stripe_payment_method_object;
+use function Sift_For_WooCommerce\Tests\Mocks\Utils\build_mock_stripe_payment_method_object;
 
 require_once __DIR__ . '/../src/inc/sift-property.php';
 require_once __DIR__ . '/../src/inc/payment-gateway.php';

--- a/tests/PaymentTypeTest.php
+++ b/tests/PaymentTypeTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare( strict_types=1 );
 /**
  * Class PaymentGatewayTest
  *

--- a/tests/PaymentTypeTest.php
+++ b/tests/PaymentTypeTest.php
@@ -1,9 +1,10 @@
-<?php declare( strict_types=1 );
+<?php
 /**
  * Class PaymentGatewayTest
  *
  * @package Sift_Decisions
  */
+declare( strict_types=1 );
 
 use Sift_For_WooCommerce\Payment_Gateway;
 use Sift_For_WooCommerce\Payment_Type;

--- a/tests/PaymentTypeTest.php
+++ b/tests/PaymentTypeTest.php
@@ -5,8 +5,8 @@
  * @package Sift_Decisions
  */
 
-use Sift_For_WooCommerce\Sift_For_WooCommerce\Payment_Gateway;
-use Sift_For_WooCommerce\Sift_For_WooCommerce\Payment_Type;
+use Sift_For_WooCommerce\Payment_Gateway;
+use Sift_For_WooCommerce\Payment_Type;
 
 require_once __DIR__ . '/../src/inc/sift-property.php';
 require_once __DIR__ . '/../src/inc/payment-gateway.php';

--- a/tests/RemoveItemFromCartEventTest.php
+++ b/tests/RemoveItemFromCartEventTest.php
@@ -9,7 +9,7 @@ require_once 'EventTest.php';
 
 // phpcs:disable Universal.Arrays.DisallowShortArraySyntax.Found, WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound
 
-use Sift_For_WooCommerce\Sift_For_WooCommerce\WooCommerce_Actions\Events;
+use Sift_For_WooCommerce\WooCommerce_Actions\Events;
 
 /**
  * Test case.

--- a/tests/RemoveItemFromCartEventTest.php
+++ b/tests/RemoveItemFromCartEventTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare( strict_types=1 );
 /**
  * Class RemoveItemFromCartEventTest
  *

--- a/tests/RemoveItemFromCartEventTest.php
+++ b/tests/RemoveItemFromCartEventTest.php
@@ -1,9 +1,10 @@
-<?php declare( strict_types=1 );
+<?php
 /**
  * Class RemoveItemFromCartEventTest
  *
  * @package Sift_For_WooCommerce
  */
+declare( strict_types=1 );
 
 require_once 'EventTest.php';
 

--- a/tests/SiftApi/SiftObjectValidatorTest.php
+++ b/tests/SiftApi/SiftObjectValidatorTest.php
@@ -4,7 +4,7 @@
 
 namespace SiftApi;
 
-use Sift_For_WooCommerce\Sift_For_WooCommerce\Sift\SiftObjectValidator;
+use Sift_For_WooCommerce\Sift\SiftObjectValidator;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/tests/SiftApi/Validate_AddItemToCart_Test.php
+++ b/tests/SiftApi/Validate_AddItemToCart_Test.php
@@ -4,7 +4,7 @@
 
 namespace SiftApi;
 
-use Sift_For_WooCommerce\Sift_For_WooCommerce\Sift\SiftObjectValidator;
+use Sift_For_WooCommerce\Sift\SiftObjectValidator;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/tests/SiftApi/Validate_CreateAccount_Test.php
+++ b/tests/SiftApi/Validate_CreateAccount_Test.php
@@ -4,7 +4,7 @@
 
 namespace SiftApi;
 
-use Sift_For_WooCommerce\Sift_For_WooCommerce\Sift\SiftObjectValidator;
+use Sift_For_WooCommerce\Sift\SiftObjectValidator;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/tests/SiftApi/Validate_CreateOrUpdateOrder_Test.php
+++ b/tests/SiftApi/Validate_CreateOrUpdateOrder_Test.php
@@ -4,7 +4,7 @@
 
 namespace SiftApi;
 
-use Sift_For_WooCommerce\Sift_For_WooCommerce\Sift\SiftObjectValidator;
+use Sift_For_WooCommerce\Sift\SiftObjectValidator;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/tests/SiftApi/Validate_LinkSessionToUser_Test.php
+++ b/tests/SiftApi/Validate_LinkSessionToUser_Test.php
@@ -4,7 +4,7 @@
 
 namespace SiftApi;
 
-use Sift_For_WooCommerce\Sift_For_WooCommerce\Sift\SiftObjectValidator;
+use Sift_For_WooCommerce\Sift\SiftObjectValidator;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/tests/SiftApi/Validate_Login_Test.php
+++ b/tests/SiftApi/Validate_Login_Test.php
@@ -4,7 +4,7 @@
 
 namespace SiftApi;
 
-use Sift_For_WooCommerce\Sift_For_WooCommerce\Sift\SiftObjectValidator;
+use Sift_For_WooCommerce\Sift\SiftObjectValidator;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/tests/SiftApi/Validate_OrderStatus_Test.php
+++ b/tests/SiftApi/Validate_OrderStatus_Test.php
@@ -4,7 +4,7 @@
 
 namespace SiftApi;
 
-use Sift_For_WooCommerce\Sift_For_WooCommerce\Sift\SiftObjectValidator;
+use Sift_For_WooCommerce\Sift\SiftObjectValidator;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/tests/SiftApi/Validate_RemoveItemFromCart_Test.php
+++ b/tests/SiftApi/Validate_RemoveItemFromCart_Test.php
@@ -4,7 +4,7 @@
 
 namespace SiftApi;
 
-use Sift_For_WooCommerce\Sift_For_WooCommerce\Sift\SiftObjectValidator;
+use Sift_For_WooCommerce\Sift\SiftObjectValidator;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/tests/SiftApi/Validate_UpdateAccount_Test.php
+++ b/tests/SiftApi/Validate_UpdateAccount_Test.php
@@ -4,7 +4,7 @@
 
 namespace SiftApi;
 
-use Sift_For_WooCommerce\Sift_For_WooCommerce\Sift\SiftObjectValidator;
+use Sift_For_WooCommerce\Sift\SiftObjectValidator;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/tests/SiftApi/Validate_UpdatePassword_Test.php
+++ b/tests/SiftApi/Validate_UpdatePassword_Test.php
@@ -4,7 +4,7 @@
 
 namespace SiftApi;
 
-use Sift_For_WooCommerce\Sift_For_WooCommerce\Sift\SiftObjectValidator;
+use Sift_For_WooCommerce\Sift\SiftObjectValidator;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/tests/StripeLibTest.php
+++ b/tests/StripeLibTest.php
@@ -3,7 +3,7 @@
  * Class StripeLibTest
  */
 
-use Sift_For_WooCommerce\Sift_For_WooCommerce\PaymentGateways\Lib\Stripe;
+use Sift_For_WooCommerce\PaymentGateways\Lib\Stripe;
 
 require_once __DIR__ . '/../src/inc/payment-gateways/lib/stripe.php';
 

--- a/tests/StripeLibTest.php
+++ b/tests/StripeLibTest.php
@@ -1,7 +1,8 @@
-<?php declare( strict_types=1 );
+<?php
 /**
  * Class StripeLibTest
  */
+declare( strict_types=1 );
 
 use Sift_For_WooCommerce\PaymentGateways\Lib\Stripe;
 

--- a/tests/StripeLibTest.php
+++ b/tests/StripeLibTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare( strict_types=1 );
 /**
  * Class StripeLibTest
  */

--- a/tests/UpdateAccountEventTest.php
+++ b/tests/UpdateAccountEventTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare( strict_types=1 );
 /**
  * Class UpdateAccountEventTest
  *

--- a/tests/UpdateAccountEventTest.php
+++ b/tests/UpdateAccountEventTest.php
@@ -9,7 +9,7 @@ require_once 'EventTest.php';
 
 // phpcs:disable Universal.Arrays.DisallowShortArraySyntax.Found, WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound
 
-use Sift_For_WooCommerce\Sift_For_WooCommerce\WooCommerce_Actions\Events;
+use Sift_For_WooCommerce\WooCommerce_Actions\Events;
 
 /**
  * Test case.

--- a/tests/UpdateAccountEventTest.php
+++ b/tests/UpdateAccountEventTest.php
@@ -1,9 +1,10 @@
-<?php declare( strict_types=1 );
+<?php
 /**
  * Class UpdateAccountEventTest
  *
  * @package Sift_For_WooCommerce
  */
+declare( strict_types=1 );
 
 require_once 'EventTest.php';
 

--- a/tests/UpdateOrderEventTest.php
+++ b/tests/UpdateOrderEventTest.php
@@ -9,7 +9,7 @@ require_once 'EventTest.php';
 
 // phpcs:disable Universal.Arrays.DisallowShortArraySyntax.Found, WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound
 
-use Sift_For_WooCommerce\Sift_For_WooCommerce\WooCommerce_Actions\Events;
+use Sift_For_WooCommerce\WooCommerce_Actions\Events;
 
 /**
  * Test case.

--- a/tests/UpdateOrderEventTest.php
+++ b/tests/UpdateOrderEventTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare( strict_types=1 );
 /**
  * Class UpdateOrderEventTest
  *

--- a/tests/UpdateOrderEventTest.php
+++ b/tests/UpdateOrderEventTest.php
@@ -1,9 +1,10 @@
-<?php declare( strict_types=1 );
+<?php
 /**
  * Class UpdateOrderEventTest
  *
  * @package Sift_For_WooCommerce
  */
+declare( strict_types=1 );
 
 require_once 'EventTest.php';
 

--- a/tests/UpdatePasswordEventTest.php
+++ b/tests/UpdatePasswordEventTest.php
@@ -9,7 +9,7 @@ require_once 'EventTest.php';
 
 // phpcs:disable Universal.Arrays.DisallowShortArraySyntax.Found, WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound
 
-use Sift_For_WooCommerce\Sift_For_WooCommerce\WooCommerce_Actions\Events;
+use Sift_For_WooCommerce\WooCommerce_Actions\Events;
 
 /**
  * Test case.

--- a/tests/UpdatePasswordEventTest.php
+++ b/tests/UpdatePasswordEventTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare( strict_types=1 );
 /**
  * Class UpdatePasswordEventTest
  *

--- a/tests/UpdatePasswordEventTest.php
+++ b/tests/UpdatePasswordEventTest.php
@@ -1,9 +1,10 @@
-<?php declare( strict_types=1 );
+<?php
 /**
  * Class UpdatePasswordEventTest
  *
  * @package Sift_For_WooCommerce
  */
+declare( strict_types=1 );
 
 require_once 'EventTest.php';
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,4 @@
-<?php declare( strict_types=1 );
+<?php
 /**
  * PHPUnit bootstrap file.
  *
@@ -6,6 +6,7 @@
  *
  * phpcs:disable
  */
+declare( strict_types=1 );
 
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare( strict_types=1 );
 /**
  * PHPUnit bootstrap file.
  *

--- a/tests/mocks/utils.php
+++ b/tests/mocks/utils.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare( strict_types=1 );
 
 namespace Sift_For_WooCommerce\Tests\Mocks\Utils;
 

--- a/tests/mocks/utils.php
+++ b/tests/mocks/utils.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Sift_For_WooCommerce\Sift_For_WooCommerce\Tests\Mocks\Utils;
+namespace Sift_For_WooCommerce\Tests\Mocks\Utils;
 
 /**
  * Build an object (or array) which represents the payment method returned by the Stripe API.

--- a/tests/mocks/wc-payments-api-charge-mock.php
+++ b/tests/mocks/wc-payments-api-charge-mock.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare( strict_types=1 );
 
 namespace Sift_For_WooCommerce\Tests\Mocks;
 

--- a/tests/mocks/wc-payments-api-charge-mock.php
+++ b/tests/mocks/wc-payments-api-charge-mock.php
@@ -1,8 +1,8 @@
 <?php declare(strict_types=1);
 
-namespace Sift_For_WooCommerce\Sift_For_WooCommerce\Tests\Mocks;
+namespace Sift_For_WooCommerce\Tests\Mocks;
 
-use function Sift_For_WooCommerce\Sift_For_WooCommerce\Tests\Mocks\Utils\build_mock_stripe_payment_method_object;
+use function Sift_For_WooCommerce\Tests\Mocks\Utils\build_mock_stripe_payment_method_object;
 
 require_once __DIR__ . '/utils.php';
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Refactor namespaces to remove duplication
* Bumps version to 1.0.0
* Enforces type strictness by making sure all files include `declare( strict_types=1 );` unless they are empty index files.
* Fix issue with `$login` event
* Fix some issues that came up from enforcing type strictness

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Automated tests should cover this. Otherwise, a full test would look like the following:
- Start the environment
- Active the sift-for-woocommerce plugin
- Navigate to the settings page and enter your sift sandbox mode API key, beacon key and account id.
- Try triggering various events (e.g., login, logout, creating orders..) and check the sift dashboard to see if the events were sent successfully.

Closes 548-gh-automattic/gold
