### PR TITLE
Fix the chargeback event

### DIFF
--- a/src/inc/payment-gateways/woocommerce-payments.php
+++ b/src/inc/payment-gateways/woocommerce-payments.php
@@ -92,6 +92,12 @@ function send_chargeback_to_sift( $event ): void {
 	$api_client     = \WC_Payments::get_payments_api_client();
 	$payment_intent = $api_client->get_intent( $payment_intent_id );
 
+	if ( ! $payment_intent ) {
+		wc_get_logger()->error( 'Payment intent with ID "' . $payment_intent_id . '"not found.' );
+		return;
+	}
+
+
 	$metadata = $payment_intent->get_metadata();
 	$order    = $payment_intent->get_order();
 

--- a/src/inc/payment-gateways/woocommerce-payments.php
+++ b/src/inc/payment-gateways/woocommerce-payments.php
@@ -97,7 +97,6 @@ function send_chargeback_to_sift( $event ): void {
 		return;
 	}
 
-
 	$metadata = $payment_intent->get_metadata();
 	$order    = $payment_intent->get_order();
 

--- a/src/inc/sift-object-validator.php
+++ b/src/inc/sift-object-validator.php
@@ -891,10 +891,15 @@ class SiftObjectValidator {
 	 * @throws \Exception If the browser is invalid.
 	 */
 	public static function validate_browser( $value ) {
+
+		if( empty( $value ) ) {
+			return true;
+		}
+
 		$validator_map = array(
 			'$user_agent'       => 'is_string',
-			'$accept_language'  => 'is_string',
-			'$content_language' => 'is_string',
+			'$accept_language'  => array( __CLASS__, 'is_string_or_null' ),
+			'$content_language' => array( __CLASS__, 'is_string_or_null' )
 		);
 		try {
 			static::validate( $value, $validator_map );
@@ -905,14 +910,25 @@ class SiftObjectValidator {
 	}
 
 	/**
+	 * Returns if the value is a string or null
+	 *
+	 * @param string $value The value.
+	 *
+	 * @returns boolean
+	 */
+	public static function is_string_or_null( mixed $value ): bool {
+		return is_string( $value ) || is_null( $value );
+	}
+
+	/**
 	 * Validate an ISO 3166 language code.
 	 *
 	 * @param string $value The ISO 3166 language code to validate.
 	 *
-	 * @return true
+	 * @return boolean
 	 * @throws \InvalidArgumentException If the ISO 3166 language code is invalid.
 	 */
-	public static function validate_ISO3166_language( $value ) { //phpcs:ignore
+	public static function validate_ISO3166_language( string $value ): bool { //phpcs:ignore
 		// ISO 3166 language code.
 		if ( ! empty( $value ) && ! preg_match( '/^[a-z]{2}-[A-Z]{2}$/', $value ) ) {
 			throw new \InvalidArgumentException( 'must be valid ISO-3166 format' );
@@ -1476,7 +1492,7 @@ class SiftObjectValidator {
 				throw new \Exception( 'missing $user_id or $session_id' );
 			}
 		} catch ( \Exception $e ) {
-			throw new \Exception( 'Invalid $link_session_to_user event: ' . esc_html( $e->getMessage() ) );
+			throw new \Exception( 'Invalid $chargeback event: ' . esc_html( $e->getMessage() ) );
 		}
 		return true;
 	}

--- a/src/inc/sift-object-validator.php
+++ b/src/inc/sift-object-validator.php
@@ -1488,15 +1488,16 @@ class SiftObjectValidator {
 
 		try {
 			static::validate( $data, $validator_map );
-			// required field: $user_id, $session_id
-			if ( empty( $data['$user_id'] ) ) {
+			// Required field: $user_id, $order_id
+			if ( empty( $data['$user_id'] ) || empty( $data['$order_id'] ) ) {
 				wc_get_logger()->error(
 					'Invalid $chargeback event',
 					array(
 						'source' => 'sift-for-woocommerce',
-						'data'   => $data,
+						'data' => $data,
 					)
 				);
+
 				throw new \Exception( 'missing $user_id or $session_id' );
 			}
 		} catch ( \Exception $e ) {

--- a/src/inc/sift-object-validator.php
+++ b/src/inc/sift-object-validator.php
@@ -1485,10 +1485,18 @@ class SiftObjectValidator {
 			'$user_id'           => array( __CLASS__, 'validate_id' ),
 			'$chargeback_reason' => 'is_string',
 		);
+
 		try {
 			static::validate( $data, $validator_map );
 			// required field: $user_id, $session_id
-			if ( empty( $data['$user_id'] ) || empty( $data['$session_id'] ) ) {
+			if ( empty( $data['$user_id'] ) ) {
+				wc_get_logger()->error(
+					'Invalid $chargeback event',
+					array(
+						'source' => 'sift-for-woocommerce',
+						'data'   => $data,
+					)
+				);
 				throw new \Exception( 'missing $user_id or $session_id' );
 			}
 		} catch ( \Exception $e ) {

--- a/src/inc/sift-object-validator.php
+++ b/src/inc/sift-object-validator.php
@@ -1308,6 +1308,9 @@ class SiftObjectValidator {
 			if( ! isset( $data['$user_id'] ) ) {
 				throw new \Exception( 'missing $user_id' );
 			}
+			if( ! isset( $data['$session_id'] ) ) {
+				throw new \Exception( 'missing $session_id' );
+			}
 		} catch ( \Exception $e ) {
 			throw new \Exception( 'Failed to validate $create_account event: ' . esc_html( $e->getMessage() ) );
 		}
@@ -1624,6 +1627,7 @@ class SiftObjectValidator {
 	public static function validate_order_status( array $data ) {
 		$validator_map = array(
 			'$user_id'      => array( __CLASS__, 'validate_id' ),
+			'$session_id'   => array( __CLASS__, 'validate_id' ),
 			'$order_id'     => 'is_string',
 			'$order_status' => self::ORDER_STATUSES,
 			'$reason'       => self::CANCELLATION_REASONS,
@@ -1643,6 +1647,9 @@ class SiftObjectValidator {
 			// Required fields for order status: $user_id, $order_id, $order_status
 			if ( !isset( $data['$user_id'] ) ) {
 				throw new \Exception( 'missing $user_id' );
+			}
+			if( ! isset( $data['$session_id'] ) ) {
+				throw new \Exception( 'missing $session_id' );
 			}
 			if ( empty( $data['$order_id'] ) ) {
 				throw new \Exception( 'missing $order_id' );
@@ -1668,6 +1675,7 @@ class SiftObjectValidator {
 	public static function validate_transaction( array $data ) {
 		$validator_map = array(
 			'$user_id'            => array( __CLASS__, 'validate_id' ),
+			'$session_id'         => array( __CLASS__, 'validate_id' ),
 			'$amount'             => 'is_int',
 			'$currency_code'      => array( __CLASS__, 'validate_currency_code' ),
 			'$order_id'           => 'is_string',
@@ -1680,6 +1688,9 @@ class SiftObjectValidator {
 			// Required fields for order status: $user_id, $order_id, $order_status
 			if( ! isset( $data['$user_id'] ) ) {
 				throw new \Exception( 'missing $user_id' );
+			}
+			if( ! isset( $data['$session_id'] ) ) {
+				throw new \Exception( 'missing $session_id' );
 			}
 			if ( empty( $data['$amount'] ) ) {
 				throw new \Exception( 'missing $amount' );

--- a/src/inc/sift-object-validator.php
+++ b/src/inc/sift-object-validator.php
@@ -1305,7 +1305,7 @@ class SiftObjectValidator {
 		try {
 			static::validate( $data, $validator_map );
 			// required field: $user_id
-			if ( empty( $data['$user_id'] ) ) {
+			if( ! isset( $data['$user_id'] ) ) {
 				throw new \Exception( 'missing $user_id' );
 			}
 		} catch ( \Exception $e ) {
@@ -1506,7 +1506,7 @@ class SiftObjectValidator {
 		try {
 			static::validate( $data, $validator_map );
 			// required field: $user_id
-			if ( empty( $data['$user_id'] ) ) {
+			if( ! isset( $data['$user_id'] ) ) {
 				throw new \Exception( 'missing $user_id' );
 			}
 		} catch ( \Exception $e ) {
@@ -1563,7 +1563,7 @@ class SiftObjectValidator {
 		try {
 			static::validate( $data, $validator_map );
 			// required field: $user_id
-			if ( empty( $data['$user_id'] ) ) {
+			if( ! isset( $data['$user_id'] ) ) {
 				throw new \Exception( 'missing $user_id' );
 			}
 		} catch ( \Exception $e ) {
@@ -1598,7 +1598,7 @@ class SiftObjectValidator {
 		try {
 			static::validate( $data, $validator_map );
 			// Required fields for update password: $user_id, $reason, $status
-			if ( empty( $data['$user_id'] ) ) {
+			if( ! isset( $data['$user_id'] ) ) {
 				throw new \Exception( 'missing $user_id' );
 			}
 			if ( empty( $data['$reason'] ) ) {
@@ -1641,7 +1641,7 @@ class SiftObjectValidator {
 		try {
 			static::validate( $data, $validator_map );
 			// Required fields for order status: $user_id, $order_id, $order_status
-			if ( empty( $data['$user_id'] ) ) {
+			if ( !isset( $data['$user_id'] ) ) {
 				throw new \Exception( 'missing $user_id' );
 			}
 			if ( empty( $data['$order_id'] ) ) {
@@ -1678,7 +1678,7 @@ class SiftObjectValidator {
 		try {
 			static::validate( $data, $validator_map );
 			// Required fields for order status: $user_id, $order_id, $order_status
-			if ( empty( $data['$user_id'] ) ) {
+			if( ! isset( $data['$user_id'] ) ) {
 				throw new \Exception( 'missing $user_id' );
 			}
 			if ( empty( $data['$amount'] ) ) {

--- a/src/inc/sift-object-validator.php
+++ b/src/inc/sift-object-validator.php
@@ -892,14 +892,14 @@ class SiftObjectValidator {
 	 */
 	public static function validate_browser( $value ) {
 
-		if( empty( $value ) ) {
+		if ( empty( $value ) ) {
 			return true;
 		}
 
 		$validator_map = array(
 			'$user_agent'       => 'is_string',
 			'$accept_language'  => array( __CLASS__, 'is_string_or_null' ),
-			'$content_language' => array( __CLASS__, 'is_string_or_null' )
+			'$content_language' => array( __CLASS__, 'is_string_or_null' ),
 		);
 		try {
 			static::validate( $value, $validator_map );
@@ -912,9 +912,9 @@ class SiftObjectValidator {
 	/**
 	 * Returns if the value is a string or null
 	 *
-	 * @param string $value The value.
+	 * @param mixed $value The value.
 	 *
-	 * @returns boolean
+	 * @return boolean
 	 */
 	public static function is_string_or_null( mixed $value ): bool {
 		return is_string( $value ) || is_null( $value );
@@ -1321,10 +1321,10 @@ class SiftObjectValidator {
 		try {
 			static::validate( $data, $validator_map );
 			// required field: $user_id
-			if( ! isset( $data['$user_id'] ) ) {
+			if ( ! isset( $data['$user_id'] ) ) {
 				throw new \Exception( 'missing $user_id' );
 			}
-			if( ! isset( $data['$session_id'] ) ) {
+			if ( ! isset( $data['$session_id'] ) ) {
 				throw new \Exception( 'missing $session_id' );
 			}
 		} catch ( \Exception $e ) {
@@ -1525,7 +1525,7 @@ class SiftObjectValidator {
 		try {
 			static::validate( $data, $validator_map );
 			// required field: $user_id
-			if( ! isset( $data['$user_id'] ) ) {
+			if ( ! isset( $data['$user_id'] ) ) {
 				throw new \Exception( 'missing $user_id' );
 			}
 		} catch ( \Exception $e ) {
@@ -1582,7 +1582,7 @@ class SiftObjectValidator {
 		try {
 			static::validate( $data, $validator_map );
 			// required field: $user_id
-			if( ! isset( $data['$user_id'] ) ) {
+			if ( ! isset( $data['$user_id'] ) ) {
 				throw new \Exception( 'missing $user_id' );
 			}
 		} catch ( \Exception $e ) {
@@ -1617,7 +1617,7 @@ class SiftObjectValidator {
 		try {
 			static::validate( $data, $validator_map );
 			// Required fields for update password: $user_id, $reason, $status
-			if( ! isset( $data['$user_id'] ) ) {
+			if ( ! isset( $data['$user_id'] ) ) {
 				throw new \Exception( 'missing $user_id' );
 			}
 			if ( empty( $data['$reason'] ) ) {
@@ -1661,10 +1661,10 @@ class SiftObjectValidator {
 		try {
 			static::validate( $data, $validator_map );
 			// Required fields for order status: $user_id, $order_id, $order_status
-			if ( !isset( $data['$user_id'] ) ) {
+			if ( ! isset( $data['$user_id'] ) ) {
 				throw new \Exception( 'missing $user_id' );
 			}
-			if( ! isset( $data['$session_id'] ) ) {
+			if ( ! isset( $data['$session_id'] ) ) {
 				throw new \Exception( 'missing $session_id' );
 			}
 			if ( empty( $data['$order_id'] ) ) {
@@ -1702,10 +1702,10 @@ class SiftObjectValidator {
 		try {
 			static::validate( $data, $validator_map );
 			// Required fields for order status: $user_id, $order_id, $order_status
-			if( ! isset( $data['$user_id'] ) ) {
+			if ( ! isset( $data['$user_id'] ) ) {
 				throw new \Exception( 'missing $user_id' );
 			}
-			if( ! isset( $data['$session_id'] ) ) {
+			if ( ! isset( $data['$session_id'] ) ) {
 				throw new \Exception( 'missing $session_id' );
 			}
 			if ( empty( $data['$amount'] ) ) {

--- a/src/inc/sift-object-validator.php
+++ b/src/inc/sift-object-validator.php
@@ -1494,7 +1494,7 @@ class SiftObjectValidator {
 					'Invalid $chargeback event',
 					array(
 						'source' => 'sift-for-woocommerce',
-						'data' => $data,
+						'data'   => $data,
 					)
 				);
 

--- a/src/inc/woocommerce-actions.php
+++ b/src/inc/woocommerce-actions.php
@@ -669,6 +669,7 @@ class Events {
 
 		$properties = array(
 			'$user_id'            => self::format_user_id( $order->get_user_id() ),
+			'$session_id'         => WC()->session->get_customer_unique_id(),
 			'$amount'             => self::get_transaction_micros( floatval( $order->get_total() ) ), // Gotta multiply it up to give an integer.
 			'$currency_code'      => $order->get_currency(),
 			'$order_id'           => (string) $order->get_id(),
@@ -709,6 +710,7 @@ class Events {
 
 		$properties = array(
 			'$user_id'      => self::format_user_id( $order->get_user_id() ),
+			'$session_id'   => WC()->session->get_customer_unique_id(),
 			'$order_id'     => (string) $order_id,
 			'$source'       => $status_transition['manual'] ? '$manual_review' : '$automated',
 			'$description'  => $status_transition['note'],

--- a/src/inc/woocommerce-actions.php
+++ b/src/inc/woocommerce-actions.php
@@ -84,7 +84,7 @@ class Events {
 		self::add(
 			'$logout',
 			array(
-				'$user_id' => $user_id,
+				'$user_id' => self::format_user_id( intval( $user_id ) ),
 				'$browser' => self::get_client_browser(), // alternately, `$app` for details of the app if not a browser.
 				'$ip'      => self::get_client_ip(),
 				'$time'    => intval( 1000 * microtime( true ) ),
@@ -109,7 +109,7 @@ class Events {
 
 		$user       = wp_get_current_user();
 		$properties = array(
-			'$user_id'    => (string) $user->ID ?? 0,
+			'$user_id'    => self::format_user_id( $user->ID ?? 0 ),
 			'$session_id' => WC()->session->get_customer_unique_id(),
 			'$promotions' => array(
 				array(
@@ -149,7 +149,7 @@ class Events {
 		}
 
 		$properties = array(
-			'$user_id'       => (string) $user->ID,
+			'$user_id'       => self::format_user_id( $user->ID ),
 			'$login_status'  => '$success',
 			'$session_id'    => WC()->session->get_customer_unique_id(),
 			'$user_email'    => $user->user_email ?? null,
@@ -191,9 +191,9 @@ class Events {
 		}
 
 		$attempted_user = get_user_by( 'login', $username );
-		$user_id        = null;
+		$user_id        = 0;
 		if ( is_object( $attempted_user ) ) {
-			$user_id = (string) $attempted_user->ID ?? null;
+			$user_id = $attempted_user->ID ?? 0;
 		}
 
 		switch ( $error->get_error_code() ) {
@@ -212,7 +212,7 @@ class Events {
 				$failure_reason = null;
 		}
 		$properties = array(
-			'$user_id'      => $user_id,
+			'$user_id'      => self::format_user_id( $user_id ),
 			'$login_status' => '$failure',
 			'$session_id'   => WC()->session->get_customer_unique_id(),
 			'$browser'      => self::get_client_browser(), // alternately, `$app` for details of the app if not a browser.
@@ -253,7 +253,7 @@ class Events {
 		$user = get_user_by( 'id', $user_id );
 
 		$properties = array(
-			'$user_id'          => (string) $user->ID,
+			'$user_id'          => self::format_user_id( $user->ID ),
 			'$session_id'       => WC()->session->get_customer_unique_id(),
 			'$user_email'       => $user->user_email ? $user->user_email : null,
 			'$name'             => $user->display_name,
@@ -308,7 +308,7 @@ class Events {
 		}
 
 		$properties = array(
-			'$user_id'          => (string) $user->ID,
+			'$user_id'          => self::format_user_id( $user->ID ),
 			'$user_email'       => $user->user_email ? $user->user_email : null,
 			'$name'             => $user->display_name,
 			'$phone'            => $user ? get_user_meta( $user->ID, 'billing_phone', true ) : null,
@@ -357,7 +357,7 @@ class Events {
 		$user = get_user_by( 'id', $user_id );
 
 		$properties = array(
-			'$user_id'      => (string) $user->ID,
+			'$user_id'      => self::format_user_id( $user->ID ),
 			'$reason'       => '$user_update', // Can alternately be `$forgot_password` or `$forced_reset` -- no real way to set those yet.
 			'$status'       => '$success', // This action only fires after the change is done.
 			'$browser'      => self::get_client_browser(),
@@ -394,7 +394,7 @@ class Events {
 		}
 
 		$properties = array(
-			'$user_id'    => $user_id,
+			'$user_id'    => self::format_user_id( intval( $user_id ) ),
 			'$session_id' => $session_id,
 			'$ip'         => self::get_client_ip(),
 			'$time'       => intval( 1000 * microtime( true ) ),
@@ -441,7 +441,7 @@ class Events {
 		}
 
 		$properties = array(
-			'$user_id'      => (string) $user->ID ?? null,
+			'$user_id'      => self::format_user_id( $user->ID ?? 0 ),
 			'$user_email'   => $user->user_email ?? null,
 			'$session_id'   => \WC()->session->get_customer_unique_id(),
 			'$item'         => array(
@@ -495,7 +495,7 @@ class Events {
 		$user      = wp_get_current_user();
 
 		$properties = array(
-			'$user_id'      => (string) $user->ID ?? null,
+			'$user_id'      => self::format_user_id( $user->ID ?? 0 ),
 			'$user_email'   => $user->user_email ? $user->user_email : null,
 			'$session_id'   => \WC()->session->get_customer_unique_id(),
 			'$item'         => array(
@@ -611,7 +611,7 @@ class Events {
 		}
 
 		$properties = array(
-			'$user_id'         => (string) $user->ID ?? null,
+			'$user_id'         => self::format_user_id( $user->ID ?? 0 ),
 			'$user_email'      => $order->get_billing_email() ? $order->get_billing_email() : null, // pulling the billing email for the order, NOT customer email
 			'$session_id'      => \WC()->session->get_customer_unique_id(),
 			'$order_id'        => $order_id,
@@ -668,7 +668,7 @@ class Events {
 		}
 
 		$properties = array(
-			'$user_id'            => (string) $order->get_user_id(),
+			'$user_id'            => self::format_user_id( $order->get_user_id() ),
 			'$amount'             => self::get_transaction_micros( floatval( $order->get_total() ) ), // Gotta multiply it up to give an integer.
 			'$currency_code'      => $order->get_currency(),
 			'$order_id'           => (string) $order->get_id(),
@@ -708,7 +708,7 @@ class Events {
 		}
 
 		$properties = array(
-			'$user_id'      => (string) $order->get_user_id(),
+			'$user_id'      => self::format_user_id( $order->get_user_id() ),
 			'$order_id'     => (string) $order_id,
 			'$source'       => $status_transition['manual'] ? '$manual_review' : '$automated',
 			'$description'  => $status_transition['note'],
@@ -779,7 +779,7 @@ class Events {
 		// Assemble the properties for the chargeback event.
 		$properties = array(
 			'$order_id'          => $order_id,
-			'$user_id'           => (string) $order->get_user_id(),
+			'$user_id'           => self::format_user_id( $order->get_user_id() ),
 			'$chargeback_reason' => $chargeback_reason,
 			'$ip'                => self::get_client_ip(),
 		);
@@ -1075,5 +1075,21 @@ class Events {
 				)
 			);
 		}
+	}
+
+	/**
+	 * Returns the right user ID.
+	 *
+	 * @param int $user_id Original user ID
+	 *
+	 * @return string Returns an empty string if the user ID is 0
+	 */
+	private static function format_user_id( int $user_id ): string {
+		if( $user_id === 0 ) {
+			// Returns empty string if the user is unknown
+			return "";
+		}
+
+		return (string) $user_id;
 	}
 }

--- a/src/inc/woocommerce-actions.php
+++ b/src/inc/woocommerce-actions.php
@@ -1064,15 +1064,15 @@ class Events {
 	/**
 	 * Returns the right user ID.
 	 *
-	 * @param int $user_id Original user ID
+	 * @param integer $user_id Original user ID.
 	 *
 	 * @return string Returns an empty string if the user ID is 0
 	 */
 	private static function format_user_id( int $user_id ): string {
-		if( $user_id === 0 ) {
+		if ( 0 === $user_id ) {
 			// Returns empty string if the user is unknown
 			// see https://developers.sift.com/tutorials/anonymous-users
-			return "";
+			return '';
 		}
 
 		return (string) $user_id;
@@ -1081,7 +1081,7 @@ class Events {
 	/**
 	 * Return the hierarchy of the product category
 	 *
-	 * @param WC_Product $product
+	 * @param WC_Product $product WooCommerce product.
 	 *
 	 * @link https://developers.sift.com/docs/curl/events-api/complex-field-types/item
 	 *
@@ -1097,11 +1097,11 @@ class Events {
 		$taxonomy  = 'product_cat'; // Taxonomy for product category
 		$terms_ids = $product->get_category_ids();
 		// Loop though terms ids (product categories)
-		foreach( $terms_ids as $term_id ) {
-			$term_names = []; // Initialising category array
+		foreach ( $terms_ids as $term_id ) {
+			$term_names = array(); // Initialising category array
 
 			// Loop through product category ancestors
-			foreach( get_ancestors( $term_id, $taxonomy ) as $ancestor_id ){
+			foreach ( get_ancestors( $term_id, $taxonomy ) as $ancestor_id ) {
 				// Add the ancestors term names to the category array
 				$term_names[] = get_term( $ancestor_id, $taxonomy )->name;
 			}
@@ -1109,9 +1109,9 @@ class Events {
 			$term_names[] = get_term( $term_id, $taxonomy )->name;
 
 			// Add the formatted ancestors with the product category to main array
-			$output[] = implode(' > ', $term_names);
+			$output[] = implode( ' > ', $term_names );
 		}
 		// Output the formatted product categories with their ancestors
-		return implode(', ', $output );
+		return implode( ', ', $output );
 	}
 }

--- a/src/sift-for-woocommerce.php
+++ b/src/sift-for-woocommerce.php
@@ -110,8 +110,8 @@ class Sift_For_WooCommerce {
 		static $client = null;
 
 		if ( null === $client ) {
-			$api_key    = get_option( 'wc_sift_for_woocommerce_api_key' );
-			$account_id = get_option( 'wc_sift_for_woocommerce_account_id' );
+			$api_key    = get_option( 'wc_sift_for_woocommerce_sift_api_key' );
+			$account_id = get_option( 'wc_sift_for_woocommerce_sift_account_id' );
 
 			if ( ! $account_id || ! $api_key ) {
 				wc_get_logger()->log(

--- a/tests/SiftApi/SiftObjectValidatorTest.php
+++ b/tests/SiftApi/SiftObjectValidatorTest.php
@@ -42,7 +42,6 @@ abstract class SiftObjectValidatorTest extends \WP_UnitTestCase {
 
 	public static function modify_data( $change_data ) {
 		$data = static::load_json();
-		unset( $data['$browser'] ); // remove the $browser key (broken by default)
 		$recursively_fix = function ( $data, $change_data ) use ( &$recursively_fix ) {
 			foreach ( $change_data as $key => $value ) {
 				if ( is_array( $value ) ) {
@@ -56,6 +55,11 @@ abstract class SiftObjectValidatorTest extends \WP_UnitTestCase {
 			return $data;
 		};
 		$data            = $recursively_fix( $data, $change_data );
+
+		if( isset( $data['$browser'] ) && isset( $data['$app'] ) ) {
+			unset( $data['$browser'] );
+		}
+
 		return $data;
 	}
 

--- a/tests/SiftApi/Validate_CreateOrUpdateOrder_Test.php
+++ b/tests/SiftApi/Validate_CreateOrUpdateOrder_Test.php
@@ -55,4 +55,37 @@ class Validate_CreateOrUpdateOrder_Test extends SiftObjectValidatorTest {
 		);
 	}
 
+	public function test_browser_no_language() {
+		$data = static::modify_data( [
+			'$app'		  => null,
+			'$browser'    => [
+				'$user_agent'       => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36',
+				'$accept_language'  => null,
+				'$content_language' => 'en-GB'
+			]
+		] );
+
+		try {
+			$this->assertTrue( static::validator( $data ) );
+		} catch ( \Exception $e ) {
+			$this->fail( $e->getMessage() );
+		}
+
+		$data = static::modify_data( [
+			'$app'		  => null,
+			'$browser' => [
+				'$user_agent'       => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36',
+				'$accept_language'  => null,
+				'$content_language' => null
+			]
+		] );
+
+		try {
+			$this->assertTrue( static::validator( $data ) );
+		} catch ( \Exception $e ) {
+			$this->fail( $e->getMessage() );
+		}
+
+	}
+
 }

--- a/tests/SiftApi/fixtures/order-status.json
+++ b/tests/SiftApi/fixtures/order-status.json
@@ -1,5 +1,6 @@
 {
 	"$user_id"          : "billy_jones_301",
+  "$session_id"       : "gigtleqddo84l8cm15qe4il",
 	"$order_id"         : "ORDER-28168441",
 	"$order_status"     : "$canceled",
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The chargeback event notification was not getting processed at all due to some bad references to the dispute object. This should correct those.

I've (temporarily) added additional logging to try to figure out why the process fails for no apparent reason right after the line `$payment_intent = $api_client->get_intent( $payment_intent_id );` in the `send_chargeback_to_sift()` method.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #
