### PR TITLE
Fix/add promotion

### DIFF
--- a/src/inc/sift-object-validator.php
+++ b/src/inc/sift-object-validator.php
@@ -1206,6 +1206,7 @@ class SiftObjectValidator {
 	public static function validate_add_promotion( $data ) {
 		$validator_map = array(
 			'$user_id'    => array( __CLASS__, 'validate_id' ),
+			'$session_id' => array( __CLASS__, 'validate_id' ),
 			'$promotions' => static::validate_array_fn( array( __CLASS__, 'validate_promotion' ) ),
 			'$browser'    => array( __CLASS__, 'validate_browser' ),
 		);

--- a/src/inc/woocommerce-actions.php
+++ b/src/inc/woocommerce-actions.php
@@ -110,6 +110,7 @@ class Events {
 		$user    = wp_get_current_user();
 		$properties = array(
 			'$user_id'    => (string) $user->ID ?? 0,
+			'$session_id' => WC()->session->get_customer_unique_id(),
 			'$promotions' => array(
 				array(
 					'$promotion_id' => $coupon_code,

--- a/src/inc/woocommerce-actions.php
+++ b/src/inc/woocommerce-actions.php
@@ -107,14 +107,14 @@ class Events {
 			return;
 		}
 
-		$user    = wp_get_current_user();
+		$user       = wp_get_current_user();
 		$properties = array(
 			'$user_id'    => (string) $user->ID ?? 0,
 			'$session_id' => WC()->session->get_customer_unique_id(),
 			'$promotions' => array(
 				array(
 					'$promotion_id' => $coupon_code,
-					'$status'		=> '$success',
+					'$status'       => '$success',
 				),
 			),
 			'$ip'         => self::get_client_ip(),

--- a/src/inc/woocommerce-actions.php
+++ b/src/inc/woocommerce-actions.php
@@ -43,7 +43,7 @@ class Events {
 		add_action( 'woocommerce_remove_cart_item', array( static::class, 'remove_item_from_cart' ), 100, 2 );
 		add_action( 'woocommerce_new_order', array( static::class, 'create_order' ), 100, 2 );
 		add_action( 'woocommerce_update_order', array( static::class, 'update_or_create_order' ), 100, 2 );
-		add_action( 'woocommerce_order_applied_coupon', array( static::class, 'add_promotion' ), 100, 2 );
+		add_action( 'woocommerce_applied_coupon', array( static::class, 'add_promotion' ), 100, 2 );
 
 		/**
 		 * We need to break this out into separate actions so we have the $status_transition available.
@@ -97,21 +97,24 @@ class Events {
 	 *
 	 * @link https://developers.sift.com/docs/curl/events-api/reserved-events/add-promotion
 	 *
-	 * @param \WC_Coupon $coupon Coupon used.
-	 * @param \WC_Order  $order  Order.
+	 * @param string $coupon_code Coupon used.
 	 *
 	 * @return void
 	 */
-	public static function add_promotion( \WC_Coupon $coupon, \WC_Order $order ): void {
+	public static function add_promotion( string $coupon_code ): void {
 
 		if ( ! Sift_Event_Types::can_event_be_sent( Sift_Event_Types::$add_promotion ) ) {
 			return;
 		}
 
+		$user    = wp_get_current_user();
 		$properties = array(
-			'$user_id'    => $order->get_user_id(),
+			'$user_id'    => (string) $user->ID ?? 0,
 			'$promotions' => array(
-				'$promotion_id' => $coupon->get_id(),
+				array(
+					'$promotion_id' => $coupon_code,
+					'$status'		=> '$success',
+				),
 			),
 			'$ip'         => self::get_client_ip(),
 			'$browser'    => self::get_client_browser(),

--- a/src/sift-for-woocommerce.php
+++ b/src/sift-for-woocommerce.php
@@ -2,8 +2,6 @@
 
 namespace Sift_For_WooCommerce;
 
-use Sift_For_WooCommerce\Sift_Events_Types\Sift_Event_Types;
-
 require_once __DIR__ . '/inc/class-sift-event-types.php';
 require_once __DIR__ . '/inc/wc-settings-tab.php';
 require_once __DIR__ . '/inc/rest-api-webhooks.php';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix $add_promotions by changing `woocommerce_order_applied_coupon` (only applies to admins) by `woocommerce_applied_coupon`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Replace the option names in sift-for-woocommerce.php (fixed in https://github.com/woocommerce/sift-for-woocommerce/pull/16)
```
$api_key    = get_option( 'wc_sift_for_woocommerce_sift_api_key' );
$account_id = get_option( 'wc_sift_for_woocommerce_sift_account_id' );
```
* Create a discount in Marketing >  Coupons
* Apply it to your checkout
* See the $add_promotions in Sift
 
<img width="900" alt="Screenshot 2024-11-21 at 19 34 45" src="https://github.com/user-attachments/assets/abfbaeee-a962-444b-b697-3f46889597be">


Mentions https://github.com/Automattic/gold/issues/551
