### PR TITLE
Add woocommerce-paypal-payments gateway support

### DIFF
--- a/src/inc/payment-gateways/load.php
+++ b/src/inc/payment-gateways/load.php
@@ -12,6 +12,9 @@ add_action(
 					require_once __DIR__ . '/lib/stripe.php';
 					require_once __DIR__ . '/stripe.php';
 					break;
+				case 'ppcp-gateway':
+					require_once __DIR__ . '/ppcp-gateway.php';
+					break;
 				case 'woopayments':
 					require_once __DIR__ . '/transact.php';
 					break;

--- a/src/inc/payment-gateways/paypal.php
+++ b/src/inc/payment-gateways/paypal.php
@@ -1,3 +1,0 @@
-<?php declare( strict_types=1 );
-
-add_filter( 'sift_for_woocommerce_paypal_payment_gateway_string', fn() => '$paypal' );

--- a/src/inc/payment-gateways/ppcp-gateway.php
+++ b/src/inc/payment-gateways/ppcp-gateway.php
@@ -15,9 +15,10 @@ add_filter( 'sift_for_woocommerce_ppcp-gateway_payment_gateway_string', fn() => 
 function get_from_order( $value, \WC_Order $order ) {
 	try {
 		$container = \WooCommerce\PayPalCommerce\PPCP::container();
+
 		return array(
 			'wc_order'      => $order,
-			'order'         => $container->get( 'api.repository.order' )->from_wc_order( $order ),
+			'order'         => $container->get( 'api.repository.order' )->for_wc_order( $order ),
 			'purchase-unit' => $container->get( 'api.factory.purchase-unit' )->from_wc_order( $order ),
 		);
 	} catch ( \Exception ) {

--- a/src/inc/payment-gateways/ppcp-gateway.php
+++ b/src/inc/payment-gateways/ppcp-gateway.php
@@ -15,31 +15,36 @@ add_filter( 'sift_for_woocommerce_ppcp-gateway_payment_gateway_string', fn() => 
  * @return array An array of 'wc_order', 'order', and 'purchase-unit' or $value if an exception was encountered.
  */
 function get_from_order( $value, \WC_Order $order ) {
-	try {
-		$container = PPCP::container();
+	$container = PPCP::container();
 
-		return array(
-			'wc_order'      => $order,
-			'order'         => $container->get( 'api.repository.order' )->for_wc_order( $order ),
-			'purchase-unit' => $container->get( 'api.factory.purchase-unit' )->from_wc_order( $order ),
-		);
-	} catch ( \Exception ) {
-		return $value;
-	}
+	$paypal_order = null;
+	$purchase_unit = null;
+	try {
+		$paypal_order = $container->get( 'api.repository.order' )->for_wc_order( $order );
+	} catch ( \Exception $e ) {}
+	try {
+		$purchase_unit = $container->get( 'api.factory.purchase-unit' )->from_wc_order( $order );
+	} catch ( \Exception $e ) {}
+
+	return array(
+		'wc_order'      => $order,
+		'order'         => $paypal_order,
+		'purchase-unit' => $purchase_unit,
+	);
 }
 add_filter( 'sift_for_woocommerce_ppcp-gateway_payment_method_details_from_order', __NAMESPACE__ . '\get_from_order', 10, 2 );
 add_filter( 'sift_for_woocommerce_ppcp-gateway_charge_details_from_order', __NAMESPACE__ . '\get_from_order', 10, 2 );
 
 add_filter( 'sift_for_woocommerce_ppcp-gateway_payment_type_string', fn( $value, $ppcp_gateway_payment_type ) => 'ppcp' === $ppcp_gateway_payment_type ? '$third_party_processor' : $value );
 
-add_filter( 'sift_for_woocommerce_ppcp-gateway_card_last4', fn( $value, $ppcp_data ) => $ppcp_data['wc_order']->get_meta_data( \WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway::FRAUD_RESULT_META_KEY )['card_last_digits'] ?? $value, 10, 2 );
-add_filter( 'sift_for_woocommerce_ppcp-gateway_avs_result_code', fn( $value, $ppcp_data ) => $ppcp_data['purchase-unit']->payments()->authorizations()[0]->fraud_processor_response()->avs_code() ?? $value, 10, 2 );
-add_filter( 'sift_for_woocommerce_ppcp-gateway_cvv_result_code', fn( $value, $ppcp_data ) => $ppcp_data['purchase-unit']->payments()->authorizations()[0]->fraud_processor_response()->cvv_code() ?? $value, 10, 2 );
-add_filter( 'sift_for_woocommerce_ppcp-gateway_verification_status', fn( $value, $ppcp_data ) => $ppcp_data['purchase-unit']->payments()->authorizations()[0]->status() ?? $value, 10, 2 );
-add_filter( 'sift_for_woocommerce_ppcp-gateway_decline_reason_code', fn( $value, $ppcp_data ) => $ppcp_data['purchase-unit']->payments()->authorizations()[0]->to_array()['reason_code'] ?? $value, 10, 2 );
+add_filter( 'sift_for_woocommerce_ppcp-gateway_card_last4', fn( $value, $ppcp_data ) => $ppcp_data['wc_order']?->get_meta_data( \WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway::FRAUD_RESULT_META_KEY )['card_last_digits'] ?? $value, 10, 2 );
+add_filter( 'sift_for_woocommerce_ppcp-gateway_avs_result_code', fn( $value, $ppcp_data ) => $ppcp_data['purchase-unit']?->payments()?->authorizations()[0]?->fraud_processor_response()->avs_code() ?? $value, 10, 2 );
+add_filter( 'sift_for_woocommerce_ppcp-gateway_cvv_result_code', fn( $value, $ppcp_data ) => $ppcp_data['purchase-unit']?->payments()?->authorizations()[0]?->fraud_processor_response()->cvv_code() ?? $value, 10, 2 );
+add_filter( 'sift_for_woocommerce_ppcp-gateway_verification_status', fn( $value, $ppcp_data ) => $ppcp_data['purchase-unit']?->payments()?->authorizations()[0]?->status() ?? $value, 10, 2 );
+add_filter( 'sift_for_woocommerce_ppcp-gateway_decline_reason_code', fn( $value, $ppcp_data ) => $ppcp_data['purchase-unit']?->payments()?->authorizations()[0]?->to_array()['reason_code'] ?? $value, 10, 2 );
 
-add_filter( 'sift_for_woocommerce_ppcp-gateway_paypal_payer_id', fn( $value, $ppcp_data ) => $ppcp_data['order']->payer()->payer_id() ?? $value, 10, 2 );
-add_filter( 'sift_for_woocommerce_ppcp-gateway_paypal_payer_email', fn( $value, $ppcp_data ) => $ppcp_data['order']->payer()->email_address() ?? $value, 10, 2 );
+add_filter( 'sift_for_woocommerce_ppcp-gateway_paypal_payer_id', fn( $value, $ppcp_data ) => $ppcp_data['order']?->payer()?->payer_id() ?? $value, 10, 2 );
+add_filter( 'sift_for_woocommerce_ppcp-gateway_paypal_payer_email', fn( $value, $ppcp_data ) => $ppcp_data['order']?->payer()?->email_address() ?? $value, 10, 2 );
 
-add_filter( 'sift_for_woocommerce_ppcp-gateway_paypal_protection_eligibility', fn( $value, $ppcp_data ) => $ppcp_data['purchase-unit']->payments()->captures()[0]->seller_protection() ?? $value, 10, 2 );
-add_filter( 'sift_for_woocommerce_ppcp-gateway_paypal_payment_status', fn( $value, $ppcp_data ) => $ppcp_data['purchase-unit']->payments()->captures()[0]->status()->name() ?? $value, 10, 2 );
+add_filter( 'sift_for_woocommerce_ppcp-gateway_paypal_protection_eligibility', fn( $value, $ppcp_data ) => $ppcp_data['purchase-unit']?->payments()?->captures()[0]->seller_protection() ?? $value, 10, 2 );
+add_filter( 'sift_for_woocommerce_ppcp-gateway_paypal_payment_status', fn( $value, $ppcp_data ) => $ppcp_data['purchase-unit']?->payments()?->captures()[0]->status()->name() ?? $value, 10, 2 );

--- a/src/inc/payment-gateways/ppcp-gateway.php
+++ b/src/inc/payment-gateways/ppcp-gateway.php
@@ -25,8 +25,8 @@ function get_from_order( $value, \WC_Order $order ) {
 		return $value;
 	}
 }
-add_filter( 'sift_for_woocommerce_ppcp-gateway_payment_method_details_from_order', 'get_from_order', 10, 2 );
-add_filter( 'sift_for_woocommerce_ppcp-gateway_charge_details_from_order', 'get_from_order', 10, 2 );
+add_filter( 'sift_for_woocommerce_ppcp-gateway_payment_method_details_from_order', __NAMESPACE__ . '\get_from_order', 10, 2 );
+add_filter( 'sift_for_woocommerce_ppcp-gateway_charge_details_from_order', __NAMESPACE__ . '\get_from_order', 10, 2 );
 
 add_filter( 'sift_for_woocommerce_ppcp-gateway_payment_type_string', fn( $value, $ppcp_gateway_payment_type ) => 'ppcp' === $ppcp_gateway_payment_type ? '$third_party_processor' : $value );
 

--- a/src/inc/payment-gateways/ppcp-gateway.php
+++ b/src/inc/payment-gateways/ppcp-gateway.php
@@ -2,6 +2,8 @@
 
 namespace Sift_For_WooCommerce\PaymentGateways\PPCP;
 
+use WooCommerce\PayPalCommerce\PPCP;
+
 add_filter( 'sift_for_woocommerce_ppcp-gateway_payment_gateway_string', fn() => '$paypal' );
 
 /**
@@ -10,11 +12,11 @@ add_filter( 'sift_for_woocommerce_ppcp-gateway_payment_gateway_string', fn() => 
  * @param mixed     $value The initial value to be returned if an exception is encountered.
  * @param \WC_Order $order The WC Order object.
  *
- * @return An array of 'wc_order', 'order', and 'purchase-unit' or $value if an exception was encountered.
+ * @return array An array of 'wc_order', 'order', and 'purchase-unit' or $value if an exception was encountered.
  */
 function get_from_order( $value, \WC_Order $order ) {
 	try {
-		$container = \WooCommerce\PayPalCommerce\PPCP::container();
+		$container = PPCP::container();
 
 		return array(
 			'wc_order'      => $order,

--- a/src/inc/payment-gateways/ppcp-gateway.php
+++ b/src/inc/payment-gateways/ppcp-gateway.php
@@ -18,14 +18,19 @@ add_filter( 'sift_for_woocommerce_ppcp-gateway_payment_gateway_string', fn() => 
 function get_from_order( $value, \WC_Order $order ) {
 	$container = PPCP::container();
 
-	$paypal_order = null;
+	$paypal_order  = null;
 	$purchase_unit = null;
 	try {
 		$paypal_order = $container->get( 'api.repository.order' )->for_wc_order( $order );
-	} catch ( \Exception $e ) {}
+	} catch ( \Exception ) {
+		wc_get_logger()->debug( 'Could not find the Paypal order' );
+	}
+
 	try {
 		$purchase_unit = $container->get( 'api.factory.purchase-unit' )->from_wc_order( $order );
-	} catch ( \Exception $e ) {}
+	} catch ( \Exception ) {
+		wc_get_logger()->debug( 'Could not find the purchase unit' );
+	}
 
 	return array(
 		'wc_order'      => $order,

--- a/src/inc/payment-gateways/ppcp-gateway.php
+++ b/src/inc/payment-gateways/ppcp-gateway.php
@@ -1,0 +1,23 @@
+<?php declare( strict_types=1 );
+
+add_filter( 'sift_for_woocommerce_ppcp-gateway_payment_gateway_string', fn() => '$paypal' );
+
+add_filter(
+	'sift_for_woocommerce_ppcp-gateway_payment_method_details_from_order',
+	function ( $value, \WC_Order $order ) {
+		return $order;
+	},
+	10,
+	2
+);
+
+add_filter(
+	'sift_for_woocommerce_ppcp-gateway_charge_details_from_order',
+	function ( $value, \WC_Order $order ) {
+		return $order;
+	},
+	10,
+	2
+);
+
+add_filter( 'sift_for_woocommerce_ppcp-gateway_payment_type_string', fn( $value, $ppcp_gateway_payment_type ) => 'ppcp' === $ppcp_gateway_payment_type ? '$third_party_processor' : $value );

--- a/src/inc/payment-gateways/ppcp-gateway.php
+++ b/src/inc/payment-gateways/ppcp-gateway.php
@@ -1,23 +1,42 @@
 <?php declare( strict_types=1 );
 
+namespace Sift_For_WooCommerce\PaymentGateways\PPCP;
+
 add_filter( 'sift_for_woocommerce_ppcp-gateway_payment_gateway_string', fn() => '$paypal' );
 
-add_filter(
-	'sift_for_woocommerce_ppcp-gateway_payment_method_details_from_order',
-	function ( $value, \WC_Order $order ) {
-		return $order;
-	},
-	10,
-	2
-);
-
-add_filter(
-	'sift_for_woocommerce_ppcp-gateway_charge_details_from_order',
-	function ( $value, \WC_Order $order ) {
-		return $order;
-	},
-	10,
-	2
-);
+/**
+ * Get relevant information from the order.
+ *
+ * @param mixed     $value The initial value to be returned if an exception is encountered.
+ * @param \WC_Order $order The WC Order object.
+ *
+ * @return An array of 'wc_order', 'order', and 'purchase-unit' or $value if an exception was encountered.
+ */
+function get_from_order( $value, \WC_Order $order ) {
+	try {
+		$container = \WooCommerce\PayPalCommerce\PPCP::container();
+		return array(
+			'wc_order'      => $order,
+			'order'         => $container->get( 'api.repository.order' )->from_wc_order( $order ),
+			'purchase-unit' => $container->get( 'api.factory.purchase-unit' )->from_wc_order( $order ),
+		);
+	} catch ( \Exception ) {
+		return $value;
+	}
+}
+add_filter( 'sift_for_woocommerce_ppcp-gateway_payment_method_details_from_order', 'get_from_order', 10, 2 );
+add_filter( 'sift_for_woocommerce_ppcp-gateway_charge_details_from_order', 'get_from_order', 10, 2 );
 
 add_filter( 'sift_for_woocommerce_ppcp-gateway_payment_type_string', fn( $value, $ppcp_gateway_payment_type ) => 'ppcp' === $ppcp_gateway_payment_type ? '$third_party_processor' : $value );
+
+add_filter( 'sift_for_woocommerce_ppcp-gateway_card_last4', fn( $value, $ppcp_data ) => $ppcp_data['wc_order']->get_meta_data( \WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway::FRAUD_RESULT_META_KEY )['card_last_digits'] ?? $value, 10, 2 );
+add_filter( 'sift_for_woocommerce_ppcp-gateway_avs_result_code', fn( $value, $ppcp_data ) => $ppcp_data['purchase-unit']->payments()->authorizations()[0]->fraud_processor_response()->avs_code() ?? $value, 10, 2 );
+add_filter( 'sift_for_woocommerce_ppcp-gateway_cvv_result_code', fn( $value, $ppcp_data ) => $ppcp_data['purchase-unit']->payments()->authorizations()[0]->fraud_processor_response()->cvv_code() ?? $value, 10, 2 );
+add_filter( 'sift_for_woocommerce_ppcp-gateway_verification_status', fn( $value, $ppcp_data ) => $ppcp_data['purchase-unit']->payments()->authorizations()[0]->status() ?? $value, 10, 2 );
+add_filter( 'sift_for_woocommerce_ppcp-gateway_decline_reason_code', fn( $value, $ppcp_data ) => $ppcp_data['purchase-unit']->payments()->authorizations()[0]->to_array()['reason_code'] ?? $value, 10, 2 );
+
+add_filter( 'sift_for_woocommerce_ppcp-gateway_paypal_payer_id', fn( $value, $ppcp_data ) => $ppcp_data['order']->payer()->payer_id() ?? $value, 10, 2 );
+add_filter( 'sift_for_woocommerce_ppcp-gateway_paypal_payer_email', fn( $value, $ppcp_data ) => $ppcp_data['order']->payer()->email_address() ?? $value, 10, 2 );
+
+add_filter( 'sift_for_woocommerce_ppcp-gateway_paypal_protection_eligibility', fn( $value, $ppcp_data ) => $ppcp_data['purchase-unit']->payments()->captures()[0]->seller_protection() ?? $value, 10, 2 );
+add_filter( 'sift_for_woocommerce_ppcp-gateway_paypal_payment_status', fn( $value, $ppcp_data ) => $ppcp_data['purchase-unit']->payments()->captures()[0]->status()->name() ?? $value, 10, 2 );

--- a/src/inc/payment-gateways/ppcp-gateway.php
+++ b/src/inc/payment-gateways/ppcp-gateway.php
@@ -3,6 +3,7 @@
 namespace Sift_For_WooCommerce\PaymentGateways\PPCP;
 
 use WooCommerce\PayPalCommerce\PPCP;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 
 add_filter( 'sift_for_woocommerce_ppcp-gateway_payment_gateway_string', fn() => '$paypal' );
 
@@ -37,7 +38,7 @@ add_filter( 'sift_for_woocommerce_ppcp-gateway_charge_details_from_order', __NAM
 
 add_filter( 'sift_for_woocommerce_ppcp-gateway_payment_type_string', fn( $value, $ppcp_gateway_payment_type ) => 'ppcp' === $ppcp_gateway_payment_type ? '$third_party_processor' : $value );
 
-add_filter( 'sift_for_woocommerce_ppcp-gateway_card_last4', fn( $value, $ppcp_data ) => $ppcp_data['wc_order']?->get_meta_data( \WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway::FRAUD_RESULT_META_KEY )['card_last_digits'] ?? $value, 10, 2 );
+add_filter( 'sift_for_woocommerce_ppcp-gateway_card_last4', fn( $value, $ppcp_data ) => $ppcp_data['wc_order']?->get_meta_data( PayPalGateway::FRAUD_RESULT_META_KEY )['card_last_digits'] ?? $value, 10, 2 );
 add_filter( 'sift_for_woocommerce_ppcp-gateway_avs_result_code', fn( $value, $ppcp_data ) => $ppcp_data['purchase-unit']?->payments()?->authorizations()[0]?->fraud_processor_response()->avs_code() ?? $value, 10, 2 );
 add_filter( 'sift_for_woocommerce_ppcp-gateway_cvv_result_code', fn( $value, $ppcp_data ) => $ppcp_data['purchase-unit']?->payments()?->authorizations()[0]?->fraud_processor_response()->cvv_code() ?? $value, 10, 2 );
 add_filter( 'sift_for_woocommerce_ppcp-gateway_verification_status', fn( $value, $ppcp_data ) => $ppcp_data['purchase-unit']?->payments()?->authorizations()[0]?->status() ?? $value, 10, 2 );

--- a/src/inc/payment-gateways/stripe.php
+++ b/src/inc/payment-gateways/stripe.php
@@ -1,6 +1,6 @@
 <?php declare( strict_types=1 );
 
-namespace Sift_For_WooCommerce\PaymentGateways;
+namespace Sift_For_WooCommerce\PaymentGateways\Stripe;
 
 use Sift_For_WooCommerce\PaymentGateways\Lib\Stripe;
 

--- a/src/inc/sift-events/class-sift-event-types.php
+++ b/src/inc/sift-events/class-sift-event-types.php
@@ -209,7 +209,6 @@ class Sift_Event_Types {
 		if ( ! $enabled ) {
 			return false;
 		}
-
-		return (bool) get_option( self::get_option_for_event_type( $event_type ), false );
+		return "yes" === get_option( self::get_option_for_event_type( $event_type ), "no" );
 	}
 }

--- a/src/inc/sift-events/class-sift-event-types.php
+++ b/src/inc/sift-events/class-sift-event-types.php
@@ -190,7 +190,7 @@ class Sift_Event_Types {
 	 *
 	 * @return string
 	 */
-	public static function get_filter_for_enabled_event_type( string $event_type ): string {
+	public static function get_filter_for_disabled_event_type( string $event_type ): string {
 		return self::get_option_for_event_type( $event_type );
 	}
 
@@ -202,11 +202,11 @@ class Sift_Event_Types {
 	 * @return boolean
 	 */
 	public static function can_event_be_sent( string $event_type ) {
-		$event_enabled_filter = self::get_filter_for_enabled_event_type( $event_type );
+		$event_disabled_filter = self::get_filter_for_disabled_event_type( $event_type );
 
-		$enabled = apply_filters( $event_enabled_filter, true ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.DynamicHooknameFound
+		$disabled = apply_filters( $event_disabled_filter, false ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.DynamicHooknameFound
 
-		if ( ! $enabled ) {
+		if ( $disabled ) {
 			return false;
 		}
 		return 'yes' === get_option( self::get_option_for_event_type( $event_type ), 'no' );

--- a/src/inc/sift-events/class-sift-event-types.php
+++ b/src/inc/sift-events/class-sift-event-types.php
@@ -209,6 +209,6 @@ class Sift_Event_Types {
 		if ( ! $enabled ) {
 			return false;
 		}
-		return "yes" === get_option( self::get_option_for_event_type( $event_type ), "no" );
+		return 'yes' === get_option( self::get_option_for_event_type( $event_type ), 'no' );
 	}
 }

--- a/src/inc/sift-events/sift-events.php
+++ b/src/inc/sift-events/sift-events.php
@@ -118,7 +118,7 @@ class Events {
 		$user       = wp_get_current_user();
 		$properties = array(
 			'$user_id'    => self::format_user_id( $user->ID ?? 0 ),
-			'$session_id' => WC()->session->get_customer_unique_id(),
+			'$session_id' => \WC()->session?->get_customer_unique_id() ?? '',
 			'$promotions' => array(
 				array(
 					'$promotion_id' => $coupon_code,
@@ -159,7 +159,7 @@ class Events {
 		$properties = array(
 			'$user_id'       => self::format_user_id( $user->ID ),
 			'$login_status'  => '$success',
-			'$session_id'    => WC()->session->get_customer_unique_id(),
+			'$session_id'    => \WC()->session?->get_customer_unique_id() ?? '',
 			'$user_email'    => $user->user_email ?? null,
 			'$browser'       => self::get_client_browser(), // alternately, `$app` for details of the app if not a browser.
 			'$username'      => $username,
@@ -222,7 +222,7 @@ class Events {
 		$properties = array(
 			'$user_id'      => self::format_user_id( $user_id ),
 			'$login_status' => '$failure',
-			'$session_id'   => WC()->session->get_customer_unique_id(),
+			'$session_id'   => \WC()->session?->get_customer_unique_id() ?? '',
 			'$browser'      => self::get_client_browser(), // alternately, `$app` for details of the app if not a browser.
 			'$username'     => $username,
 			'$ip'           => self::get_client_ip(),
@@ -262,7 +262,7 @@ class Events {
 
 		$properties = array(
 			'$user_id'          => self::format_user_id( $user->ID ),
-			'$session_id'       => WC()->session->get_customer_unique_id(),
+			'$session_id'       => \WC()->session?->get_customer_unique_id() ?? '',
 			'$user_email'       => $user->user_email ? $user->user_email : null,
 			'$name'             => $user->display_name,
 			'$phone'            => $user ? get_user_meta( $user->ID, 'billing_phone', true ) : null,
@@ -446,7 +446,7 @@ class Events {
 		$properties = array(
 			'$user_id'      => self::format_user_id( $user->ID ?? 0 ),
 			'$user_email'   => $user->user_email ?? null,
-			'$session_id'   => WC()->session->get_customer_unique_id(),
+			'$session_id'   => \WC()->session?->get_customer_unique_id() ?? '',
 			'$item'         => array(
 				'$item_id'       => (string) $cart_item_key,
 				'$sku'           => $product->get_sku(),
@@ -500,7 +500,7 @@ class Events {
 		$properties = array(
 			'$user_id'      => self::format_user_id( $user->ID ?? 0 ),
 			'$user_email'   => $user->user_email ? $user->user_email : null,
-			'$session_id'   => \WC()->session->get_customer_unique_id(),
+			'$session_id'   => \WC()->session?->get_customer_unique_id() ?? '',
 			'$item'         => array(
 				'$item_id'       => (string) $product->get_id(),
 				'$sku'           => $product->get_sku(),
@@ -717,8 +717,8 @@ class Events {
 
 		$properties = array(
 			'$user_id'      => self::format_user_id( $order->get_user_id() ),
-			'$session_id'   => WC()->session->get_customer_unique_id(),
-			'$order_id'     => (string) $order_id,
+			'$session_id'   => \WC()->session?->get_customer_unique_id() ?? '',
+			'$order_id'     => $order_id,
 			'$source'       => $status_transition['manual'] ? '$manual_review' : '$automated',
 			'$description'  => $status_transition['note'],
 			'$browser'      => self::get_client_browser(),

--- a/src/inc/sift-events/sift-events.php
+++ b/src/inc/sift-events/sift-events.php
@@ -611,7 +611,7 @@ class Events {
 		$properties = array(
 			'$user_id'         => '',
 			'$user_email'      => $order->get_billing_email() ? $order->get_billing_email() : null, // pulling the billing email for the order, NOT customer email
-			'$session_id'      => \WC()->session->get_customer_unique_id(),
+			'$session_id'      => \WC()->session?->get_customer_unique_id() ?? '',
 			'$order_id'        => $order_id,
 			'$verification_phone_number'
 				=> '+' === substr( $order->get_billing_phone(), 0, 1 ) ? preg_replace( '/[^0-9\+]/', '', $order->get_billing_phone() ) : null,
@@ -676,7 +676,7 @@ class Events {
 
 		$properties = array(
 			'$user_id'            => self::format_user_id( $order->get_user_id() ),
-			'$session_id'         => WC()->session->get_customer_unique_id(),
+			'$session_id'         => \WC()->session?->get_customer_unique_id() ?? '',
 			'$amount'             => self::get_transaction_micros( floatval( $order->get_total() ) ), // Gotta multiply it up to give an integer.
 			'$currency_code'      => $order->get_currency(),
 			'$order_id'           => (string) $order->get_id(),

--- a/src/inc/wc-admin-settings-tab.php
+++ b/src/inc/wc-admin-settings-tab.php
@@ -377,7 +377,6 @@ function test_api_credentials_result( $api_key = null, $account_id = null ) {
 
 	$code   = $response->httpStatusCode;
 	$data   = $response->body;
-	$return = null;
 
 	if ( 200 === $code ) {
 		$return = sprintf( '<h4>%s</h4>', __( 'Credentials are valid!', 'sift-for-woocommerce' ) );

--- a/src/inc/wc-admin-settings-tab.php
+++ b/src/inc/wc-admin-settings-tab.php
@@ -375,8 +375,8 @@ function test_api_credentials_result( $api_key = null, $account_id = null ) {
 	$client   = Sift_For_WooCommerce::get_api_client();
 	$response = $client->listAllWebhooks();
 
-	$code   = $response->httpStatusCode;
-	$data   = $response->body;
+	$code = $response->httpStatusCode;
+	$data = $response->body;
 
 	if ( 200 === $code ) {
 		$return = sprintf( '<h4>%s</h4>', __( 'Credentials are valid!', 'sift-for-woocommerce' ) );

--- a/tests/DisabledEventTest.php
+++ b/tests/DisabledEventTest.php
@@ -36,13 +36,13 @@ class DisabledEventTest extends EventTest {
 		self::reset_events();
 
 		// Disable the event
-		add_filter( Sift_Event_Types::get_filter_for_enabled_event_type( $event_type ), '__return_false' );
+		add_filter( Sift_Event_Types::get_filter_for_disabled_event_type( $event_type ), '__return_true' );
 		$callback();
 		self::fail_on_error_logged();
 		self::assertNoEventSent( $event_type );
 
 		// Enable the event
-		remove_filter( Sift_Event_Types::get_filter_for_enabled_event_type( $event_type ), '__return_false' );
+		remove_filter( Sift_Event_Types::get_filter_for_disabled_event_type( $event_type ), '__return_true' );
 		$callback();
 		self::fail_on_error_logged();
 		self::assertEventSent( $event_type );

--- a/tests/DisabledEventTest.php
+++ b/tests/DisabledEventTest.php
@@ -50,7 +50,7 @@ class DisabledEventTest extends EventTest {
 		self::reset_events();
 
 		// Uncheck the event from the admin
-		update_option( Sift_Event_Types::get_option_for_event_type( $event_type ), false );
+		update_option( Sift_Event_Types::get_option_for_event_type( $event_type ), "no" );
 		$callback();
 		self::fail_on_error_logged();
 		self::assertNoEventSent( $event_type );

--- a/tests/DisabledEventTest.php
+++ b/tests/DisabledEventTest.php
@@ -50,7 +50,7 @@ class DisabledEventTest extends EventTest {
 		self::reset_events();
 
 		// Uncheck the event from the admin
-		update_option( Sift_Event_Types::get_option_for_event_type( $event_type ), "no" );
+		update_option( Sift_Event_Types::get_option_for_event_type( $event_type ), 'no' );
 		$callback();
 		self::fail_on_error_logged();
 		self::assertNoEventSent( $event_type );

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -51,20 +51,20 @@ abstract class EventTest extends WP_UnitTestCase {
 		add_filter( 'woocommerce_logger_log_message', array( __CLASS__, 'log_watcher' ), 10, 2 );
 
 		// We enable all the event types by default
-		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$add_item_to_cart ), "yes" );
-		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$remove_item_from_cart ), "yes" );
-		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$link_session_to_user ), "yes" );
-		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$create_order ), "yes" );
-		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$update_order ), "yes" );
-		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$update_password ), "yes" );
-		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$chargeback ), "yes" );
-		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$transaction ), "yes" );
-		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$order_status ), "yes" );
-		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$create_account ), "yes" );
-		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$update_account ), "yes" );
-		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$add_promotion ), "yes" );
-		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$login ), "yes" );
-		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$logout ), "yes" );
+		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$add_item_to_cart ), 'yes' );
+		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$remove_item_from_cart ), 'yes' );
+		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$link_session_to_user ), 'yes' );
+		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$create_order ), 'yes' );
+		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$update_order ), 'yes' );
+		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$update_password ), 'yes' );
+		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$chargeback ), 'yes' );
+		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$transaction ), 'yes' );
+		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$order_status ), 'yes' );
+		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$create_account ), 'yes' );
+		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$update_account ), 'yes' );
+		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$add_promotion ), 'yes' );
+		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$login ), 'yes' );
+		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$logout ), 'yes' );
 	}
 
 	/**

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -51,20 +51,20 @@ abstract class EventTest extends WP_UnitTestCase {
 		add_filter( 'woocommerce_logger_log_message', array( __CLASS__, 'log_watcher' ), 10, 2 );
 
 		// We enable all the event types by default
-		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$add_item_to_cart ), true );
-		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$remove_item_from_cart ), true );
-		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$link_session_to_user ), true );
-		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$create_order ), true );
-		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$update_order ), true );
-		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$update_password ), true );
-		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$chargeback ), true );
-		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$transaction ), true );
-		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$order_status ), true );
-		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$create_account ), true );
-		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$update_account ), true );
-		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$add_promotion ), true );
-		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$login ), true );
-		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$logout ), true );
+		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$add_item_to_cart ), "yes" );
+		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$remove_item_from_cart ), "yes" );
+		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$link_session_to_user ), "yes" );
+		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$create_order ), "yes" );
+		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$update_order ), "yes" );
+		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$update_password ), "yes" );
+		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$chargeback ), "yes" );
+		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$transaction ), "yes" );
+		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$order_status ), "yes" );
+		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$create_account ), "yes" );
+		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$update_account ), "yes" );
+		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$add_promotion ), "yes" );
+		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$login ), "yes" );
+		update_option( Sift_Event_Types::get_option_for_event_type( Sift_Event_Types::$logout ), "yes" );
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds support for [woocommerce-paypal-payments](https://plugins.trac.wordpress.org/browser/woocommerce-paypal-payments) (`ppcp-gateway`)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Install this patch to an environment with woocommerce-paypal-payments or start this local dev environment (`npx wp-env start`) and install woocommerce-paypal-payments. Configure the plugin if needed.
* Test making an order and check the sift API logs for errors and warnings.
* Make sure the payment_method information is correct for each event.

Closes 554-gh-automattic/gold
