### PR TITLE
WIP Handle Sift decisions

### DIFF
--- a/src/inc/sift-decisions/abuse-decisions.php
+++ b/src/inc/sift-decisions/abuse-decisions.php
@@ -16,7 +16,6 @@ require_once __DIR__ . '/sift-decision-rest-api-webhooks.php';
  * @return mixed
  */
 function process_sift_decision_received( $return_value, $decision_id, $entity_id ) {
-	// We can rename once we have a final name.
 	switch ( $decision_id ) {
 		case 'trust_list_payment_abuse':
 			do_action( 'sift_for_woocommerce_trust_list_payment_abuse', $entity_id );

--- a/src/inc/sift-decisions/abuse-decisions.php
+++ b/src/inc/sift-decisions/abuse-decisions.php
@@ -48,6 +48,10 @@ function process_sift_decision_received( $return_value, $decision_id, $user_id )
 			do_action( 'sift_for_woocommerce_block_wo_review_payment_abuse', $woocommerce_user_id );
 			break;
 
+		case 'fraud_no_review_ticket_payment_abuse':
+			do_action( 'sift_for_woocommerce_fraud_no_review_ticket_payment_abuse', $woocommerce_user_id );
+			break;
+
 		case 'looks_ok_payment_abuse':
 		case 'looks_suspicious_payment_abuse':
 		case 'order_looks_ok_payment_abuse':

--- a/src/inc/sift-decisions/abuse-decisions.php
+++ b/src/inc/sift-decisions/abuse-decisions.php
@@ -57,9 +57,10 @@ function process_sift_decision_received( $return_value, $decision_id, $user_id )
 				'info',
 				"Decision ID '{$decision_id}' not handled.",
 				array(
-					'source'      => 'sift-for-woocommerce',
-					'decision_id' => $decision_id,
-					'user_id'     => $user_id,
+					'source'              => 'sift-for-woocommerce',
+					'decision_id'         => $decision_id,
+					'sift_user_id'        => $user_id,
+					'woocommerce_user_id' => $woocommerce_user_id,
 				)
 			);
 			break;

--- a/src/inc/sift-decisions/abuse-decisions.php
+++ b/src/inc/sift-decisions/abuse-decisions.php
@@ -16,17 +16,6 @@ require_once __DIR__ . '/sift-decision-rest-api-webhooks.php';
  * @return mixed
  */
 function process_sift_decision_received( $return_value, $decision_id, $user_id ) {
-	// Log the decision.
-	wc_get_logger()->log(
-		'debug',
-		'Sift Decision Filter Applied',
-		array(
-			'source'      => 'sift-for-woocommerce',
-			'decision_id' => $decision_id,
-			'user_id'     => $user_id,
-		)
-	);
-
 	// Apply a filter to get the correct user ID.
 	$woocommerce_user_id = apply_filters( 'sift_for_woocommerce_pre_sift_decision', $user_id );
 
@@ -75,6 +64,18 @@ function process_sift_decision_received( $return_value, $decision_id, $user_id )
 			);
 			break;
 	}
+
+	// Log the decision.
+	wc_get_logger()->log(
+		'debug',
+		'Sift Decision Filter Applied',
+		array(
+			'source'              => 'sift-for-woocommerce',
+			'decision_id'         => $decision_id,
+			'sift_user_id'        => $user_id,
+			'woocommerce_user_id' => $woocommerce_user_id,
+		)
+	);
 
 	return $return_value;
 }

--- a/src/inc/sift-decisions/abuse-decisions.php
+++ b/src/inc/sift-decisions/abuse-decisions.php
@@ -9,50 +9,73 @@ require_once __DIR__ . '/sift-decision-rest-api-webhooks.php';
  *
  * @param mixed   $return_value The return value.
  * @param string  $decision_id  The ID of the Sift decision.
- * @param integer $entity_id    The ID of the entity the decision corresponds to.
+ * @param integer $user_id      The user ID the decision corresponds to.
  *
  * @phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
  *
  * @return mixed
  */
-function process_sift_decision_received( $return_value, $decision_id, $entity_id ) {
+function process_sift_decision_received( $return_value, $decision_id, $user_id ) {
+	// Log the decision.
+	wc_get_logger()->log(
+		'debug',
+		'Sift Decision Filter Applied',
+		array(
+			'source'      => 'sift-for-woocommerce',
+			'decision_id' => $decision_id,
+			'user_id'     => $user_id,
+		)
+	);
+
+	// Apply a filter to get the correct user ID.
+	$woocommerce_user_id = apply_filters( 'sift_for_woocommerce_pre_sift_decision', $user_id );
+
 	switch ( $decision_id ) {
 		case 'trust_list_payment_abuse':
-			do_action( 'sift_for_woocommerce_trust_list_payment_abuse', $entity_id );
+			do_action( 'sift_for_woocommerce_trust_list_payment_abuse', $woocommerce_user_id );
 			break;
 
 		case 'looks_good_payment_abuse':
-			do_action( 'sift_for_woocommerce_looks_good_payment_abuse', $entity_id );
+			do_action( 'sift_for_woocommerce_looks_good_payment_abuse', $woocommerce_user_id );
 			break;
 
 		case 'not_likely_fraud_payment_abuse':
-			do_action( 'sift_for_woocommerce_not_likely_fraud_payment_abuse', $entity_id );
+			do_action( 'sift_for_woocommerce_not_likely_fraud_payment_abuse', $woocommerce_user_id );
 			break;
 
 		case 'likely_fraud_refundno_renew_payment_abuse':
-			do_action( 'sift_for_woocommerce_likely_fraud_refundno_renew_payment_abuse', $entity_id );
+			do_action( 'sift_for_woocommerce_likely_fraud_refundno_renew_payment_abuse', $woocommerce_user_id );
 			break;
 
 		case 'likely_fraud_keep_purchases_payment_abuse':
-			do_action( 'sift_for_woocommerce_likely_fraud_keep_purchases_payment_abuse', $entity_id );
+			do_action( 'sift_for_woocommerce_likely_fraud_keep_purchases_payment_abuse', $woocommerce_user_id );
 			break;
 
 		case 'fraud_payment_abuse':
-			do_action( 'sift_for_woocommerce_fraud_payment_abuse', $entity_id );
+			do_action( 'sift_for_woocommerce_fraud_payment_abuse', $woocommerce_user_id );
 			break;
 
 		case 'block_wo_review_payment_abuse':
-			do_action( 'sift_for_woocommerce_block_wo_review_payment_abuse', $entity_id );
+			do_action( 'sift_for_woocommerce_block_wo_review_payment_abuse', $woocommerce_user_id );
 			break;
 
 		case 'looks_ok_payment_abuse':
 		case 'looks_suspicious_payment_abuse':
 		case 'order_looks_ok_payment_abuse':
 		case 'order_looks_suspicious_payment_abuse':
-			// Not Currently Implemented.
+		default:
+			wc_get_logger()->log(
+				'info',
+				"Decision ID '{$decision_id}' not handled.",
+				array(
+					'source'      => 'sift-for-woocommerce',
+					'decision_id' => $decision_id,
+					'user_id'     => $user_id,
+				)
+			);
 			break;
 	}
 
 	return $return_value;
 }
-add_filter( 'sift_decision_received', __NAMESPACE__ . '\process_sift_decision_received', 10, 5 );
+add_filter( 'sift_decision_received', __NAMESPACE__ . '\process_sift_decision_received', 10, 3 );

--- a/src/inc/sift-events/sift-events.php
+++ b/src/inc/sift-events/sift-events.php
@@ -804,6 +804,53 @@ class Events {
 	}
 
 	/**
+	 * Get any new abuse decisions for a user, and apply it if needed.
+	 *
+	 * @param string $sift_user_id  The user ID sent to Sift, usually the WPCOM user ID.
+	 * @param string $wccom_user_id The WooCommerce user ID.
+	 *
+	 * @return string|null
+	 */
+	public static function get_decision( string $sift_user_id, string $wccom_user_id ): ?string {
+		$client = \Sift_For_WooCommerce\Sift_For_WooCommerce::get_api_client();
+		if ( empty( $client ) ) {
+			wc_get_logger()->error(
+				'Failed to get the Sift API client.',
+				array(
+					'source' => 'sift-events',
+				)
+			);
+			return null;
+		}
+
+		// Get the abuse decision from Sift.
+		$user_decisions_response = $client->getUserDecisions( $sift_user_id );
+
+		$decision_id = null;
+
+		// Extract the decision ID for payment abuse if it exists.
+		if ( isset( $user_decisions_response->body['decisions']['payment_abuse']['decision']['id'] ) ) {
+			$decision_id = $user_decisions_response->body['decisions']['payment_abuse']['decision']['id'];
+		}
+
+		return self::apply_decision( $decision_id, $wccom_user_id );
+	}
+
+	/**
+	 * Apply the decision to the filter.
+	 * This is a helper function to apply the decision to the filter.
+	 *
+	 * @param string $decision_id The decision ID.
+	 * @param string $user_id     The user ID.
+	 *
+	 * @return void
+	 */
+	public static function apply_decision( string $decision_id, string $user_id ) {
+		\apply_filters( 'sift_decision_received', null, $decision_id, $user_id );
+	}
+
+
+	/**
 	 * Enqueue an event to send.  This will enable sending them all at shutdown.
 	 *
 	 * @param string $event      The event we're recording -- generally will start with a $.
@@ -851,7 +898,22 @@ class Events {
 			}
 
 			foreach ( self::$to_send as $entry ) {
+				// We need the original WC user ID to handle the decision locally.
+				$wccom_user_id = $entry['properties']['$user_id'] ?? null;
+
+				// Apply the filter to update from the WCCOM to the WPCOM user_id just before sending the event.
+				$entry['properties'] = apply_filters( 'sift_for_woocommerce_pre_send_event_properties', $entry['properties'] );
+
 				$response = $client->track( $entry['event'], $entry['properties'] );
+
+				// Get the user ID we send Sift (probably WPCOM) from the properties.
+				$sift_user_id = $entry['properties']['$user_id'] ?? null;
+
+				// If there's no WPCOM user_id, Sift cannot deliver a decision.
+				if ( $sift_user_id ) {
+					// Get the decision for the user and apply if needed.
+					self::get_decision( $sift_user_id, $wccom_user_id );
+				}
 
 				$log_type  = 'debug';
 				$log_title = sprintf( 'Sent `%s`', $entry['event'] );

--- a/src/inc/sift-events/sift-events.php
+++ b/src/inc/sift-events/sift-events.php
@@ -829,6 +829,18 @@ class Events {
 
 		$decision_id = null;
 
+		// If $user_decisions_response->body['decisions'] is empty, log the info.
+		if ( empty( $user_decisions_response->body['decisions'] ) ) {
+			wc_get_logger()->info(
+				'No decisions found for user',
+				array(
+					'source'       => 'sift-events',
+					'sift_user_id' => $sift_user_id,
+				)
+			);
+			return null;
+		}
+
 		// Extract the decision ID for payment abuse if it exists.
 		if ( isset( $user_decisions_response->body['decisions']['payment_abuse']['decision']['id'] ) ) {
 			$decision_id = $user_decisions_response->body['decisions']['payment_abuse']['decision']['id'];
@@ -904,9 +916,6 @@ class Events {
 			foreach ( self::$to_send as $entry ) {
 				// We need the original user ID to handle the decision locally after events are sent.
 				$user_id = $entry['properties']['$user_id'] ?? null;
-
-				// Apply the filter to possibly update from the stored user_id to the WPCOM user_id just before sending the event.
-				$entry['properties'] = apply_filters( 'sift_for_woocommerce_pre_send_event_properties', $entry['properties'] );
 
 				$response = $client->track( $entry['event'], $entry['properties'] );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR handles the decisions that are set by/on Sift for an account.

When an event happens, it fetches the decision currently on Sift for that matched user. It then changes the local user's meta to either be blocked, or delete the meta that blocks the user from purchasing. Depending on the severity level of the decision, further actions (like cancelling/refunding orders or cancelling subscriptions) will also happen in the background.

The related diff ([#](https://github.com/Automattic/woocommerce.com/pull/22402)) has a number of changes and corrections, based off of work in this [diff](https://github.com/Automattic/woocommerce.com/pull/22399/).

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You'll want to use a real WPCOM account that is not your A8C account to test.
* It will require the changes in this PR: https://github.com/Automattic/woocommerce.com/pull/22402
* You will also need the WooCommerce Subscriptions plugin, and an simple subscription product to purchase.

1. Once both PRs are patched, purchase the test item (normal and subscription) so that they exist on your user's account. Verify in My Account on the test site that the purchases and subscriptions exist.
2. You'll need to next mark your user as "Fraud, No Review Ticket" using the Decisions button at the top-right of the user's Sift profile ([example](https://console.sift.com/users/92339144/overview?abuse_type=payment_abuse)).
3.  Go back into the shop interface and attempt more purchases; you should get error messages and be blocked from checking out.
4. Under My Account in your test site, in Orders, you should see any orders get refunded (they are cancelled at this point). Any subscriptions you had should now be gone; check in the admin to verify the cancelled subscriptions.

You can also check the database in wp_usermeta; there should be meta for `is_blocked_from_purchases` set as `1` if the user is blocked.

5. Go back to Sift, and change your user's decision to "Looks Good" or "Trust List".
6. Go back into the test shop, and try adding products back to the cart and purchasing. You should be allowed to purchase again.
