### PR TITLE
Add customer payment methods and PPCP chargeback reporting

### DIFF
--- a/src/inc/payment-gateways/ppcp-gateway.php
+++ b/src/inc/payment-gateways/ppcp-gateway.php
@@ -8,19 +8,6 @@ use Sift_For_WooCommerce\Sift_Events\Events;
 
 add_filter( 'sift_for_woocommerce_ppcp-gateway_payment_gateway_string', fn() => '$paypal' );
 
-add_action(
-	'woocommerce_payments_before_webhook_delivery',
-	function ( $event_type, $event_body ) {
-		// Using a switch case since we'll likely handle more future event types
-		switch ( $event_type ) {
-			case 'CUSTOMER.DISPUTE.CREATED':
-				send_chargeback_to_sift( $event_body );
-				break;
-		}
-	},
-	10,
-	2
-);
 /**
  * Get relevant information from the order.
  *

--- a/src/inc/payment-gateways/ppcp-gateway.php
+++ b/src/inc/payment-gateways/ppcp-gateway.php
@@ -52,5 +52,5 @@ add_filter( 'sift_for_woocommerce_ppcp-gateway_decline_reason_code', fn( $value,
 add_filter( 'sift_for_woocommerce_ppcp-gateway_paypal_payer_id', fn( $value, $ppcp_data ) => $ppcp_data['order']?->payer()?->payer_id() ?? $value, 10, 2 );
 add_filter( 'sift_for_woocommerce_ppcp-gateway_paypal_payer_email', fn( $value, $ppcp_data ) => $ppcp_data['order']?->payer()?->email_address() ?? $value, 10, 2 );
 
-add_filter( 'sift_for_woocommerce_ppcp-gateway_paypal_protection_eligibility', fn( $value, $ppcp_data ) => $ppcp_data['order']?->purchase_units()[0]?->payments()?->captures()[0]?->seller_protection()->name() ?? $value, 10, 2 );
+add_filter( 'sift_for_woocommerce_ppcp-gateway_paypal_protection_eligibility', fn( $value, $ppcp_data ) => $ppcp_data['order']?->purchase_units()[0]?->payments()?->captures()[0]?->seller_protection() ?? $value, 10, 2 );
 add_filter( 'sift_for_woocommerce_ppcp-gateway_paypal_payment_status', fn( $value, $ppcp_data ) => $ppcp_data['order']?->purchase_units()[0]?->payments()?->captures()[0]->status()->name() ?? $value, 10, 2 );

--- a/src/inc/payment-gateways/ppcp-gateway.php
+++ b/src/inc/payment-gateways/ppcp-gateway.php
@@ -44,13 +44,13 @@ add_filter( 'sift_for_woocommerce_ppcp-gateway_charge_details_from_order', __NAM
 add_filter( 'sift_for_woocommerce_ppcp-gateway_payment_type_string', fn( $value, $ppcp_gateway_payment_type ) => 'ppcp' === $ppcp_gateway_payment_type ? '$third_party_processor' : $value );
 
 add_filter( 'sift_for_woocommerce_ppcp-gateway_card_last4', fn( $value, $ppcp_data ) => $ppcp_data['wc_order']?->get_meta_data( PayPalGateway::FRAUD_RESULT_META_KEY )['card_last_digits'] ?? $value, 10, 2 );
-add_filter( 'sift_for_woocommerce_ppcp-gateway_avs_result_code', fn( $value, $ppcp_data ) => $ppcp_data['purchase-unit']?->payments()?->authorizations()[0]?->fraud_processor_response()->avs_code() ?? $value, 10, 2 );
-add_filter( 'sift_for_woocommerce_ppcp-gateway_cvv_result_code', fn( $value, $ppcp_data ) => $ppcp_data['purchase-unit']?->payments()?->authorizations()[0]?->fraud_processor_response()->cvv_code() ?? $value, 10, 2 );
-add_filter( 'sift_for_woocommerce_ppcp-gateway_verification_status', fn( $value, $ppcp_data ) => $ppcp_data['purchase-unit']?->payments()?->authorizations()[0]?->status() ?? $value, 10, 2 );
-add_filter( 'sift_for_woocommerce_ppcp-gateway_decline_reason_code', fn( $value, $ppcp_data ) => $ppcp_data['purchase-unit']?->payments()?->authorizations()[0]?->to_array()['reason_code'] ?? $value, 10, 2 );
+add_filter( 'sift_for_woocommerce_ppcp-gateway_avs_result_code', fn( $value, $ppcp_data ) => $ppcp_data['order']?->purchase_units()[0]?->payments()?->authorizations()[0]?->fraud_processor_response()->avs_code() ?? $value, 10, 2 );
+add_filter( 'sift_for_woocommerce_ppcp-gateway_cvv_result_code', fn( $value, $ppcp_data ) => $ppcp_data['order']?->purchase_units()[0]?->payments()?->authorizations()[0]?->fraud_processor_response()->cvv_code() ?? $value, 10, 2 );
+add_filter( 'sift_for_woocommerce_ppcp-gateway_verification_status', fn( $value, $ppcp_data ) => $ppcp_data['order']?->purchase_units()[0]?->payments()?->authorizations()[0]?->status() ?? $value, 10, 2 );
+add_filter( 'sift_for_woocommerce_ppcp-gateway_decline_reason_code', fn( $value, $ppcp_data ) => $ppcp_data['order']?->purchase_units()[0]?->payments()?->authorizations()[0]?->to_array()['reason_code'] ?? $value, 10, 2 );
 
 add_filter( 'sift_for_woocommerce_ppcp-gateway_paypal_payer_id', fn( $value, $ppcp_data ) => $ppcp_data['order']?->payer()?->payer_id() ?? $value, 10, 2 );
 add_filter( 'sift_for_woocommerce_ppcp-gateway_paypal_payer_email', fn( $value, $ppcp_data ) => $ppcp_data['order']?->payer()?->email_address() ?? $value, 10, 2 );
 
-add_filter( 'sift_for_woocommerce_ppcp-gateway_paypal_protection_eligibility', fn( $value, $ppcp_data ) => $ppcp_data['purchase-unit']?->payments()?->captures()[0]->seller_protection() ?? $value, 10, 2 );
-add_filter( 'sift_for_woocommerce_ppcp-gateway_paypal_payment_status', fn( $value, $ppcp_data ) => $ppcp_data['purchase-unit']?->payments()?->captures()[0]->status()->name() ?? $value, 10, 2 );
+add_filter( 'sift_for_woocommerce_ppcp-gateway_paypal_protection_eligibility', fn( $value, $ppcp_data ) => $ppcp_data['order']?->purchase_units()[0]?->payments()?->captures()[0]?->seller_protection() ?? $value, 10, 2 );
+add_filter( 'sift_for_woocommerce_ppcp-gateway_paypal_payment_status', fn( $value, $ppcp_data ) => $ppcp_data['order']?->purchase_units()[0]?->payments()?->captures()[0]->status()->name() ?? $value, 10, 2 );

--- a/src/inc/payment-gateways/ppcp-gateway.php
+++ b/src/inc/payment-gateways/ppcp-gateway.php
@@ -52,5 +52,5 @@ add_filter( 'sift_for_woocommerce_ppcp-gateway_decline_reason_code', fn( $value,
 add_filter( 'sift_for_woocommerce_ppcp-gateway_paypal_payer_id', fn( $value, $ppcp_data ) => $ppcp_data['order']?->payer()?->payer_id() ?? $value, 10, 2 );
 add_filter( 'sift_for_woocommerce_ppcp-gateway_paypal_payer_email', fn( $value, $ppcp_data ) => $ppcp_data['order']?->payer()?->email_address() ?? $value, 10, 2 );
 
-add_filter( 'sift_for_woocommerce_ppcp-gateway_paypal_protection_eligibility', fn( $value, $ppcp_data ) => $ppcp_data['order']?->purchase_units()[0]?->payments()?->captures()[0]?->seller_protection() ?? $value, 10, 2 );
+add_filter( 'sift_for_woocommerce_ppcp-gateway_paypal_protection_eligibility', fn( $value, $ppcp_data ) => $ppcp_data['order']?->purchase_units()[0]?->payments()?->captures()[0]?->seller_protection()?->status ?? $value, 10, 2 );
 add_filter( 'sift_for_woocommerce_ppcp-gateway_paypal_payment_status', fn( $value, $ppcp_data ) => $ppcp_data['order']?->purchase_units()[0]?->payments()?->captures()[0]->status()->name() ?? $value, 10, 2 );

--- a/src/inc/payment-gateways/ppcp-gateway.php
+++ b/src/inc/payment-gateways/ppcp-gateway.php
@@ -46,11 +46,11 @@ add_filter( 'sift_for_woocommerce_ppcp-gateway_payment_type_string', fn( $value,
 add_filter( 'sift_for_woocommerce_ppcp-gateway_card_last4', fn( $value, $ppcp_data ) => $ppcp_data['wc_order']?->get_meta_data( PayPalGateway::FRAUD_RESULT_META_KEY )['card_last_digits'] ?? $value, 10, 2 );
 add_filter( 'sift_for_woocommerce_ppcp-gateway_avs_result_code', fn( $value, $ppcp_data ) => $ppcp_data['order']?->purchase_units()[0]?->payments()?->authorizations()[0]?->fraud_processor_response()->avs_code() ?? $value, 10, 2 );
 add_filter( 'sift_for_woocommerce_ppcp-gateway_cvv_result_code', fn( $value, $ppcp_data ) => $ppcp_data['order']?->purchase_units()[0]?->payments()?->authorizations()[0]?->fraud_processor_response()->cvv_code() ?? $value, 10, 2 );
-add_filter( 'sift_for_woocommerce_ppcp-gateway_verification_status', fn( $value, $ppcp_data ) => $ppcp_data['order']?->purchase_units()[0]?->payments()?->authorizations()[0]?->status() ?? $value, 10, 2 );
+add_filter( 'sift_for_woocommerce_ppcp-gateway_verification_status', fn( $value, $ppcp_data ) => $ppcp_data['order']?->purchase_units()[0]?->payments()?->authorizations()[0]?->status()->name() ?? $value, 10, 2 );
 add_filter( 'sift_for_woocommerce_ppcp-gateway_decline_reason_code', fn( $value, $ppcp_data ) => $ppcp_data['order']?->purchase_units()[0]?->payments()?->authorizations()[0]?->to_array()['reason_code'] ?? $value, 10, 2 );
 
 add_filter( 'sift_for_woocommerce_ppcp-gateway_paypal_payer_id', fn( $value, $ppcp_data ) => $ppcp_data['order']?->payer()?->payer_id() ?? $value, 10, 2 );
 add_filter( 'sift_for_woocommerce_ppcp-gateway_paypal_payer_email', fn( $value, $ppcp_data ) => $ppcp_data['order']?->payer()?->email_address() ?? $value, 10, 2 );
 
-add_filter( 'sift_for_woocommerce_ppcp-gateway_paypal_protection_eligibility', fn( $value, $ppcp_data ) => $ppcp_data['order']?->purchase_units()[0]?->payments()?->captures()[0]?->seller_protection() ?? $value, 10, 2 );
+add_filter( 'sift_for_woocommerce_ppcp-gateway_paypal_protection_eligibility', fn( $value, $ppcp_data ) => $ppcp_data['order']?->purchase_units()[0]?->payments()?->captures()[0]?->seller_protection()->name() ?? $value, 10, 2 );
 add_filter( 'sift_for_woocommerce_ppcp-gateway_paypal_payment_status', fn( $value, $ppcp_data ) => $ppcp_data['order']?->purchase_units()[0]?->payments()?->captures()[0]->status()->name() ?? $value, 10, 2 );

--- a/src/inc/payment-gateways/ppcp-gateway.php
+++ b/src/inc/payment-gateways/ppcp-gateway.php
@@ -77,7 +77,7 @@ add_filter( 'sift_for_woocommerce_ppcp-gateway_paypal_payment_status', fn( $valu
  * @return void
  */
 function send_chargeback_to_sift( $event ): void {
-	$order_id = $event['data']['object']['resource']['disputed_transactions'][0]['seller_transaction_id'];
+	$order_id = $event['data']['object']['resource']['disputed_transactions'][0]['seller_transaction_id'] ?? null;
 	// Log the resolved order ID.
 	if ( ! $order_id ) {
 		wc_get_logger()->error( 'Order ID not found in event.' );
@@ -90,7 +90,7 @@ function send_chargeback_to_sift( $event ): void {
 		return;
 	}
 
-	$chargeback_reason = convert_dispute_reason_to_sift_chargeback_reason( $event['data']['object']['resource']['reason'] );
+	$chargeback_reason = convert_dispute_reason_to_sift_chargeback_reason( $event['data']['object']['resource']['reason'] ?? '' );
 
 	Events::chargeback( $order_id, $order, $chargeback_reason );
 }

--- a/src/inc/payment-gateways/woocommerce-payments.php
+++ b/src/inc/payment-gateways/woocommerce-payments.php
@@ -32,7 +32,7 @@ add_filter(
 			$api_client = \WC_Payments::get_payments_api_client();
 			$charge     = $api_client->get_charge( $charge_id );
 			return $charge['payment_method_details'];
-		} catch ( \Exception $e ) {
+		} catch ( \Exception ) {
 			return $value;
 		}
 	},
@@ -50,7 +50,7 @@ add_filter(
 			}
 			$api_client = \WC_Payments::get_payments_api_client();
 			return $api_client->get_charge( $charge_id );
-		} catch ( \Exception $e ) {
+		} catch ( \Exception ) {
 			return $value;
 		}
 	},

--- a/src/inc/payment-gateways/woocommerce-payments.php
+++ b/src/inc/payment-gateways/woocommerce-payments.php
@@ -27,14 +27,12 @@ add_filter(
 		try {
 			$charge_id = \WC_Payments::get_order_service()->get_charge_id_for_order( $order );
 			if ( empty( $charge_id ) ) {
-				error_log( '[sift-for-woocommerce] woocommerce-payments - Could not get charge_id from order, could not obtain payment method details.' );
 				return $value;
 			}
 			$api_client = \WC_Payments::get_payments_api_client();
 			$charge     = $api_client->get_charge( $charge_id );
 			return $charge['payment_method_details'];
 		} catch ( \Exception $e ) {
-			error_log( '[sift-for-woocommerce] woocommerce-payments - Caught exception when getting payment method details from order: ' . $e->getMessage() );
 			return $value;
 		}
 	},
@@ -48,13 +46,11 @@ add_filter(
 		try {
 			$charge_id = \WC_Payments::get_order_service()->get_charge_id_for_order( $order );
 			if ( empty( $charge_id ) ) {
-				error_log( '[sift-for-woocommerce] woocommerce-payments - could not get charge_id from order, could not obtain charge details.' );
 				return $value;
 			}
 			$api_client = \WC_Payments::get_payments_api_client();
 			return $api_client->get_charge( $charge_id );
 		} catch ( \Exception $e ) {
-			error_log( '[sift-for-woocommerce] woocommerce-payments - Caught exception when getting charge details from order: ' . $e->getMessage() );
 			return $value;
 		}
 	},

--- a/src/inc/payment-gateways/woocommerce-payments.php
+++ b/src/inc/payment-gateways/woocommerce-payments.php
@@ -27,12 +27,14 @@ add_filter(
 		try {
 			$charge_id = \WC_Payments::get_order_service()->get_charge_id_for_order( $order );
 			if ( empty( $charge_id ) ) {
+				error_log( '[sift-for-woocommerce] woocommerce-payments - Could not get charge_id from order, could not obtain payment method details.' );
 				return $value;
 			}
 			$api_client = \WC_Payments::get_payments_api_client();
 			$charge     = $api_client->get_charge( $charge_id );
 			return $charge['payment_method_details'];
-		} catch ( \Exception ) {
+		} catch ( \Exception $e ) {
+			error_log( '[sift-for-woocommerce] woocommerce-payments - Caught exception when getting payment method details from order: ' . $e->getMessage() );
 			return $value;
 		}
 	},
@@ -46,11 +48,13 @@ add_filter(
 		try {
 			$charge_id = \WC_Payments::get_order_service()->get_charge_id_for_order( $order );
 			if ( empty( $charge_id ) ) {
+				error_log( '[sift-for-woocommerce] woocommerce-payments - could not get charge_id from order, could not obtain charge details.' );
 				return $value;
 			}
 			$api_client = \WC_Payments::get_payments_api_client();
 			return $api_client->get_charge( $charge_id );
-		} catch ( \Exception ) {
+		} catch ( \Exception $e ) {
+			error_log( '[sift-for-woocommerce] woocommerce-payments - Caught exception when getting charge details from order: ' . $e->getMessage() );
 			return $value;
 		}
 	},

--- a/src/inc/sift-events/sift-events.php
+++ b/src/inc/sift-events/sift-events.php
@@ -575,7 +575,7 @@ class Events {
 
 		// Figure out if it should use the session ID if no logged-in user exists.
 		if ( ! $user_id || $is_admin ) {
-			$user_id = $is_system ? $order->get_user_id() : null; // Use order user ID only for system actions.
+			$user_id = $is_system || $is_admin ? $order->get_user_id() : null; // Use order user ID only for system actions.
 		}
 
 		$user = $user_id ? get_userdata( $user_id ) : null;

--- a/src/inc/sift-events/sift-events.php
+++ b/src/inc/sift-events/sift-events.php
@@ -1069,6 +1069,7 @@ class Events {
 		 * @return boolean True if this method of payment method lookup should be used, otherwise false.
 		 */
 		if ( apply_filters( 'sift_for_woocommerce_get_customer_payment_methods_via_order_enumeration', true, $user_id ) ) {
+			error_log( '[sift-for-woocommerce] will enumerate orders while getting customer payment methods' );
 			$customer_orders = wc_get_orders(
 				array(
 					'limit'    => -1,
@@ -1083,6 +1084,8 @@ class Events {
 				},
 				$customer_orders
 			);
+			error_log( '[sift-for-woocommerce] got payment methods from enumerate orders while getting customer payment methods:' );
+			error_log( print_r( $payment_methods, true ) );
 		}
 
 		/**
@@ -1092,8 +1095,12 @@ class Events {
 		 * @param integer $user_id         The User / Customer ID.
 		 */
 		$payment_methods = apply_filters( 'sift_for_woocommerce_get_customer_payment_methods', $payment_methods, $user_id ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+		error_log( '[sift-for-woocommerce] filtered payment methods while getting customer payment methods:' );
+		error_log( print_r( $payment_methods, true ) );
 
 		$payment_methods = array_reduce( $payment_methods, fn( $payment_method ) => ! empty( $payment_method ) && ! in_array( $payment_method, $payment_methods, true ) );
+		error_log( '[sift-for-woocommerce] reduced filtered payment methods while getting customer payment methods:' );
+		error_log( print_r( $payment_methods, true ) );
 
 		return $payment_methods ?? array();
 	}

--- a/src/inc/sift-events/sift-events.php
+++ b/src/inc/sift-events/sift-events.php
@@ -1022,6 +1022,23 @@ class Events {
 	private static function get_customer_payment_methods( int $user_id ) {
 		$payment_methods = array();
 
+		$customer_orders = wc_get_orders(
+			array(
+				'limit'    => -1,
+				'customer' => $user_id,
+				'status'   => wc_get_is_paid_statuses(),
+			)
+		);
+
+		$payment_methods = array_map(
+			function ( $order ) {
+				return $this->get_order_payment_methods( $order );
+			},
+			$customer_orders
+		);
+
+		$payment_methods = array_reduce( $payment_methods, fn( $payment_method ) => ! in_array( $payment_method, $payment_methods, true ) );
+
 		/**
 		 * Include a filter here for unexpected payment providers to be able to add their results in as well.
 		 *

--- a/src/inc/sift-events/sift-events.php
+++ b/src/inc/sift-events/sift-events.php
@@ -569,20 +569,13 @@ class Events {
 		}
 
 		// Determine user and session context.
-		$user_id   = get_current_user_id() ?? wp_get_current_user()->ID ?? null; // Check first for logged-in user.
-		$is_system = ! $create_order && str_starts_with( sanitize_title( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ?? '' ) ), 'WordPress' ); // Check if this is an order update via system action.
+		$user_id   = wp_get_current_user()->ID ?? null; // Check first for logged-in user.
 		$is_admin  = 1 === $user_id;
 
 		// Figure out if it should use the session ID if no logged-in user exists.
-		if ( ! $user_id && $is_system ) {
-			$user_id = $order->get_user_id() ?? null; // Use order user ID if is a system update
-		}
-
 		if ( ! $user_id || $is_admin ) {
 			$user_id = $order->get_user_id() ?? null; // Use order user ID if it isn't available otherwise
 		}
-
-		$user = $user_id ? get_userdata( $user_id ) : null;
 
 		$physical_or_electronic = '$electronic';
 		$items                  = array();
@@ -637,8 +630,8 @@ class Events {
 
 		// Add the user_id only if a user exists, otherwise, let it remain empty.
 		// Ref: https://developers.sift.com/docs/php/apis-overview/core-topics/faq/tracking-users
-		if ( $user ) {
-			$properties['$user_id'] = self::format_user_id( $user->ID );
+		if ( $user_id && ! $is_admin ) {
+			$properties['$user_id'] = self::format_user_id( $user_id );
 		}
 
 		// Add in the address information if it's available.

--- a/src/inc/sift-events/sift-events.php
+++ b/src/inc/sift-events/sift-events.php
@@ -1061,7 +1061,7 @@ class Events {
 
 		$payment_methods = array_reduce( $payment_methods, fn( $payment_method ) => ! empty( $payment_method ) && ! in_array( $payment_method, $payment_methods, true ) );
 
-		return $payment_methods ?? [];
+		return $payment_methods ?? array();
 	}
 
 	/**

--- a/src/inc/sift-events/sift-events.php
+++ b/src/inc/sift-events/sift-events.php
@@ -867,6 +867,7 @@ class Events {
 	 * @return boolean
 	 */
 	public static function send() {
+		error_log( '[sift-for-woocommerce] send called with ' . static::count() . ' events to send' );
 		if ( self::count() > 0 ) {
 			$client = \Sift_For_WooCommerce\Sift_For_WooCommerce::get_api_client();
 			if ( empty( $client ) ) {
@@ -908,8 +909,10 @@ class Events {
 			// Now that it's sent, clear the $to_send static in case it was run manually.
 			self::$to_send = array();
 
+			error_log( '[sift-for-woocommerce] send finished, returning true' );
 			return true;
 		}
+		error_log( '[sift-for-woocommerce] send finished, returning false' );
 		return false;
 	}
 

--- a/src/inc/sift-events/sift-events.php
+++ b/src/inc/sift-events/sift-events.php
@@ -1034,7 +1034,7 @@ class Events {
 		 *
 		 * @return boolean True if this method of payment method lookup should be used, otherwise false.
 		 */
-		if ( apply_filters( 'sift_for_woocommerce_get_customer_payment_methods_via_order_enumeration', false, $user_id ) ) {
+		if ( apply_filters( 'sift_for_woocommerce_get_customer_payment_methods_via_order_enumeration', true, $user_id ) ) {
 			$customer_orders = wc_get_orders(
 				array(
 					'limit'    => -1,

--- a/src/inc/sift-events/sift-events.php
+++ b/src/inc/sift-events/sift-events.php
@@ -1032,12 +1032,12 @@ class Events {
 
 		$payment_methods = array_map(
 			function ( $order ) {
-				return $this->get_order_payment_methods( $order );
+				return $this->get_order_payment_methods( $order )[0] ?? null;
 			},
 			$customer_orders
 		);
 
-		$payment_methods = array_reduce( $payment_methods, fn( $payment_method ) => ! in_array( $payment_method, $payment_methods, true ) );
+		$payment_methods = array_reduce( $payment_methods, fn( $payment_method ) => ! empty( $payment_method ) && ! in_array( $payment_method, $payment_methods, true ) );
 
 		/**
 		 * Include a filter here for unexpected payment providers to be able to add their results in as well.

--- a/src/inc/sift-events/sift-events.php
+++ b/src/inc/sift-events/sift-events.php
@@ -332,6 +332,10 @@ class Events {
 			'$time'             => intval( 1000 * microtime( true ) ),
 		);
 
+		if ( empty( $properties['$payment_methods'] ) ) {
+			unset( $properties['$payment_methods'] );
+		}
+
 		try {
 			SiftEventsValidator::validate_update_account( $properties );
 		} catch ( \Exception $e ) {

--- a/src/inc/sift-events/sift-events.php
+++ b/src/inc/sift-events/sift-events.php
@@ -1105,7 +1105,8 @@ class Events {
 					$payment_methods[] = $payment_method;
 				}
 				return $payment_methods;
-			}
+			},
+			array()
 		);
 		error_log( '[sift-for-woocommerce] reduced filtered payment methods while getting customer payment methods:' );
 		error_log( print_r( $payment_methods, true ) );

--- a/src/inc/sift-events/sift-events.php
+++ b/src/inc/sift-events/sift-events.php
@@ -586,7 +586,7 @@ class Events {
 
 		// Figure out if it should use the session ID if no logged-in user exists.
 		if ( ! $user_id || $is_admin ) {
-			$user_id = $is_system || $is_admin ? $order->get_user_id() : null; // Use order user ID only for system actions.
+			$user_id = $order->get_user_id() ?? null; // Use order user ID if it isn't available otherwise
 			error_log( '[sift-for-woocommerce] user_id (from order) ' . $user_id );
 		}
 

--- a/src/inc/sift-events/sift-events.php
+++ b/src/inc/sift-events/sift-events.php
@@ -25,6 +25,8 @@ use WC_Product;
 class Events {
 	public static $to_send = array();
 
+	private static $sift_orders = array();
+
 	const SUPPORTED_WOO_ORDER_STATUS_CHANGES = array(
 		'pending',
 		'processing',
@@ -1126,8 +1128,10 @@ class Events {
 	 */
 	private static function get_order_payment_methods( \WC_Order $order ) {
 		error_log( '[sift-for-woocommerce] getting order payment methods' );
-		$sift_order = new Sift_Order( $order );
-		return $sift_order->get_payment_methods();
+		if ( ! array_key_exists( $order->get_order_key(), static::$sift_orders ) ) {
+			static::$sift_orders[ $order->get_order_key() ] = new Sift_Order( $order );
+		}
+		return static::$sift_orders[ $order->get_order_key() ]->get_payment_methods();
 	}
 
 	/**

--- a/src/inc/sift-events/sift-events.php
+++ b/src/inc/sift-events/sift-events.php
@@ -649,7 +649,7 @@ class Events {
 		);
 
 		error_log( '[sift-for-woocommerce] $payment_methods: ' );
-		error_log( print_r( $properties['$payment_methods'] ) );
+		error_log( print_r( $properties['$payment_methods'], true ) );
 
 		// Add the user_id only if a user exists, otherwise, let it remain empty.
 		// Ref: https://developers.sift.com/docs/php/apis-overview/core-topics/faq/tracking-users

--- a/src/inc/sift-events/sift-events.php
+++ b/src/inc/sift-events/sift-events.php
@@ -574,12 +574,12 @@ class Events {
 		$is_admin  = 1 === $user_id;
 
 		// Figure out if it should use the session ID if no logged-in user exists.
-		if ( ! $user_id || $is_admin ) {
-			$user_id = $order->get_user_id() ?? null; // Use order user ID if it isn't available otherwise
+		if ( ! $user_id && $is_system ) {
+			$user_id = $order->get_user_id() ?? null; // Use order user ID if is a system update
 		}
 
-		if ( ! $user_id ) {
-			$user_id = \WC()->session->get_customer_unique_id();
+		if ( ! $user_id || $is_admin ) {
+			$user_id = $order->get_user_id() ?? null; // Use order user ID if it isn't available otherwise
 		}
 
 		$user = $user_id ? get_userdata( $user_id ) : null;

--- a/src/inc/sift-events/sift-events.php
+++ b/src/inc/sift-events/sift-events.php
@@ -559,6 +559,11 @@ class Events {
 	 * @return void
 	 */
 	public static function update_or_create_order( string $order_id, \WC_Order $order, bool $create_order = false ) {
+		if ( $create_order ) {
+			error_log( '[sift-for-woocommerce] creating order' );
+		} else {
+			error_log( '[sift-for-woocommerce] updating order' );
+		}
 
 		if ( ! in_array( $order->get_status(), self::SUPPORTED_WOO_ORDER_STATUS_CHANGES, true ) ) {
 			return;
@@ -572,15 +577,22 @@ class Events {
 		$user_id   = get_current_user_id() ?? wp_get_current_user()->ID ?? null; // Check first for logged-in user.
 		$is_system = ! $create_order && str_starts_with( sanitize_title( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ?? '' ) ), 'WordPress' ); // Check if this is an order update via system action.
 		$is_admin  = 1 === $user_id;
+		error_log( '[sift-for-woocommerce] get_current_user_id() ' . get_current_user_id() );
+		error_log( '[sift-for-woocommerce] wp_get_current_user()->ID ' . wp_get_current_user()->ID );
+		error_log( '[sift-for-woocommerce] user_id ' . $user_id );
+		error_log( '[sift-for-woocommerce] is_system ' . $is_system );
+		error_log( '[sift-for-woocommerce] is_admin ' . $is_admin );
 
 		// Figure out if it should use the session ID if no logged-in user exists.
 		if ( ! $user_id || $is_admin ) {
 			$user_id = $is_system || $is_admin ? $order->get_user_id() : null; // Use order user ID only for system actions.
 		}
+		error_log( '[sift-for-woocommerce] user_id (from order) ' . $user_id );
 
 		if ( ! $user_id ) {
 			$user_id = \WC()->session->get_customer_unique_id();
 		}
+		error_log( '[sift-for-woocommerce] user_id (from customer unique id) ' . $user_id );
 
 		$user = $user_id ? get_userdata( $user_id ) : null;
 
@@ -1029,6 +1041,7 @@ class Events {
 	 * @return array
 	 */
 	private static function get_customer_payment_methods( int $user_id ) {
+		error_log( '[sift-for-woocommerce] getting customer payment methods' );
 		$payment_methods = array();
 
 		/**
@@ -1084,6 +1097,7 @@ class Events {
 	 * @return array
 	 */
 	private static function get_order_payment_methods( \WC_Order $order ) {
+		error_log( '[sift-for-woocommerce] getting order payment methods' );
 		$sift_order = new Sift_Order( $order );
 		return $sift_order->get_payment_methods();
 	}

--- a/src/inc/sift-events/sift-events.php
+++ b/src/inc/sift-events/sift-events.php
@@ -578,6 +578,10 @@ class Events {
 			$user_id = $is_system || $is_admin ? $order->get_user_id() : null; // Use order user ID only for system actions.
 		}
 
+		if ( ! $user_id ) {
+			$user_id = \WC()->session->get_customer_unique_id();
+		}
+
 		$user = $user_id ? get_userdata( $user_id ) : null;
 
 		$physical_or_electronic = '$electronic';

--- a/src/inc/sift-events/sift-events.php
+++ b/src/inc/sift-events/sift-events.php
@@ -17,6 +17,7 @@ use WC_Order_Item_Product;
 
 use Sift_For_WooCommerce\Sift_Order;
 use Sift_For_WooCommerce\Sift\SiftEventsValidator;
+use Sift_For_WooCommerce\Sift_For_WooCommerce;
 use WC_Product;
 
 /**
@@ -24,8 +25,6 @@ use WC_Product;
  */
 class Events {
 	public static $to_send = array();
-
-	private static $sift_orders = array();
 
 	const SUPPORTED_WOO_ORDER_STATUS_CHANGES = array(
 		'pending',
@@ -1093,10 +1092,7 @@ class Events {
 	 * @return array
 	 */
 	private static function get_order_payment_methods( \WC_Order $order ) {
-		if ( ! array_key_exists( $order->get_order_key(), static::$sift_orders ) ) {
-			static::$sift_orders[ $order->get_order_key() ] = new Sift_Order( $order );
-		}
-		return static::$sift_orders[ $order->get_order_key() ]->get_payment_methods();
+		return Sift_For_WooCommerce::get_instance()->get_sift_order_from_wc_order( $order )->get_payment_methods();
 	}
 
 	/**

--- a/src/inc/sift-events/sift-events.php
+++ b/src/inc/sift-events/sift-events.php
@@ -560,10 +560,11 @@ class Events {
 	 */
 	public static function update_or_create_order( string $order_id, \WC_Order $order, bool $create_order = false ) {
 		if ( $create_order ) {
-			error_log( '[sift-for-woocommerce] creating order' );
+			error_log( '[sift-for-woocommerce] creating order ' . $order_id );
 		} else {
-			error_log( '[sift-for-woocommerce] updating order' );
+			error_log( '[sift-for-woocommerce] updating order ' . $order_id );
 		}
+		error_log( '[sift-for-woocommerce] order number '. $order->get_order_number() );
 
 		if ( ! in_array( $order->get_status(), self::SUPPORTED_WOO_ORDER_STATUS_CHANGES, true ) ) {
 			return;
@@ -577,22 +578,22 @@ class Events {
 		$user_id   = get_current_user_id() ?? wp_get_current_user()->ID ?? null; // Check first for logged-in user.
 		$is_system = ! $create_order && str_starts_with( sanitize_title( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ?? '' ) ), 'WordPress' ); // Check if this is an order update via system action.
 		$is_admin  = 1 === $user_id;
-		error_log( '[sift-for-woocommerce] get_current_user_id() ' . get_current_user_id() );
-		error_log( '[sift-for-woocommerce] wp_get_current_user()->ID ' . wp_get_current_user()->ID );
-		error_log( '[sift-for-woocommerce] user_id ' . $user_id );
+		error_log( '[sift-for-woocommerce] 1: get_current_user_id() ' . get_current_user_id() );
+		error_log( '[sift-for-woocommerce] 2: wp_get_current_user()->ID ' . wp_get_current_user()->ID );
+		error_log( '[sift-for-woocommerce] user_id (from 1 or 2) ' . $user_id );
 		error_log( '[sift-for-woocommerce] is_system ' . $is_system );
 		error_log( '[sift-for-woocommerce] is_admin ' . $is_admin );
 
 		// Figure out if it should use the session ID if no logged-in user exists.
 		if ( ! $user_id || $is_admin ) {
 			$user_id = $is_system || $is_admin ? $order->get_user_id() : null; // Use order user ID only for system actions.
+			error_log( '[sift-for-woocommerce] user_id (from order) ' . $user_id );
 		}
-		error_log( '[sift-for-woocommerce] user_id (from order) ' . $user_id );
 
 		if ( ! $user_id ) {
 			$user_id = \WC()->session->get_customer_unique_id();
+			error_log( '[sift-for-woocommerce] user_id (from customer unique id) ' . $user_id );
 		}
-		error_log( '[sift-for-woocommerce] user_id (from customer unique id) ' . $user_id );
 
 		$user = $user_id ? get_userdata( $user_id ) : null;
 
@@ -646,6 +647,9 @@ class Events {
 			'$ip'              => self::get_client_ip(),
 			'$time'            => intval( 1000 * microtime( true ) ),
 		);
+
+		error_log( '[sift-for-woocommerce] $payment_methods: ' );
+		error_log( print_r( $properties['$payment_methods'] ) );
 
 		// Add the user_id only if a user exists, otherwise, let it remain empty.
 		// Ref: https://developers.sift.com/docs/php/apis-overview/core-topics/faq/tracking-users

--- a/src/inc/sift-events/sift-events.php
+++ b/src/inc/sift-events/sift-events.php
@@ -1098,7 +1098,7 @@ class Events {
 		error_log( '[sift-for-woocommerce] filtered payment methods while getting customer payment methods:' );
 		error_log( print_r( $payment_methods, true ) );
 
-		$payment_methods = array_reduce( $payment_methods, fn( $payment_method ) => ! empty( $payment_method ) && ! in_array( $payment_method, $payment_methods, true ) );
+		$payment_methods = array_filter( $payment_methods, fn( $payment_method ) => ! empty( $payment_method ) && ! in_array( $payment_method, $payment_methods, true ) );
 		error_log( '[sift-for-woocommerce] reduced filtered payment methods while getting customer payment methods:' );
 		error_log( print_r( $payment_methods, true ) );
 

--- a/src/inc/sift-events/sift-events.php
+++ b/src/inc/sift-events/sift-events.php
@@ -571,9 +571,10 @@ class Events {
 		// Determine user and session context.
 		$user_id   = get_current_user_id() ?? wp_get_current_user()->ID ?? null; // Check first for logged-in user.
 		$is_system = ! $create_order && str_starts_with( sanitize_title( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ?? '' ) ), 'WordPress' ); // Check if this is an order update via system action.
+		$is_admin  = 1 === $user_id;
 
 		// Figure out if it should use the session ID if no logged-in user exists.
-		if ( ! $user_id ) {
+		if ( ! $user_id || $is_admin ) {
 			$user_id = $is_system ? $order->get_user_id() : null; // Use order user ID only for system actions.
 		}
 

--- a/src/inc/sift-events/sift-events.php
+++ b/src/inc/sift-events/sift-events.php
@@ -565,7 +565,7 @@ class Events {
 		}
 
 		// Determine user and session context.
-		$user_id   = wp_get_current_user()->ID ?? null; // Check first for logged-in user.
+		$user_id   = get_current_user_id() ?? wp_get_current_user()->ID ?? null; // Check first for logged-in user.
 		$is_system = ! $create_order && str_starts_with( sanitize_title( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ?? '' ) ), 'WordPress' ); // Check if this is an order update via system action.
 
 		// Figure out if it should use the session ID if no logged-in user exists.

--- a/src/inc/sift-events/sift-events.php
+++ b/src/inc/sift-events/sift-events.php
@@ -569,8 +569,8 @@ class Events {
 		}
 
 		// Determine user and session context.
-		$user_id   = wp_get_current_user()->ID ?? null; // Check first for logged-in user.
-		$is_admin  = 1 === $user_id;
+		$user_id  = wp_get_current_user()->ID ?? null; // Check first for logged-in user.
+		$is_admin = 1 === $user_id;
 
 		// Figure out if it should use the session ID if no logged-in user exists.
 		if ( ! $user_id || $is_admin ) {

--- a/src/inc/sift-events/sift-events.php
+++ b/src/inc/sift-events/sift-events.php
@@ -836,9 +836,12 @@ class Events {
 	 * @return void
 	 */
 	public static function add( string $event, array $properties ) {
-
+		error_log( '[sift-for-woocommerce] add ' . $event . ' with properties:' );
+		error_log( print_r( $properties, true ) );
 		// Give a chance for the platform to modify the data (and add potentially new custom data)
 		$properties = apply_filters( 'sift_for_woocommerce_pre_send_event_properties', $properties, $event );
+		error_log( '[sift-for-woocommerce] add ' . $event . ' with filtered properties:' );
+		error_log( print_r( $properties, true ) );
 
 		array_push(
 			self::$to_send,
@@ -867,6 +870,7 @@ class Events {
 		if ( self::count() > 0 ) {
 			$client = \Sift_For_WooCommerce\Sift_For_WooCommerce::get_api_client();
 			if ( empty( $client ) ) {
+				error_log( '[sift-for-woocommerce] send failed to send events to Sift (no client)' );
 				wc_get_logger()->error(
 					'Failed to send events to Sift',
 					array(
@@ -898,6 +902,7 @@ class Events {
 						'response'   => $response,
 					)
 				);
+				error_log( '[sift-for-woocommerce] send ' . $log_title );
 			}
 
 			// Now that it's sent, clear the $to_send static in case it was run manually.

--- a/src/inc/sift-events/sift-events.php
+++ b/src/inc/sift-events/sift-events.php
@@ -564,7 +564,7 @@ class Events {
 		} else {
 			error_log( '[sift-for-woocommerce] updating order ' . $order_id );
 		}
-		error_log( '[sift-for-woocommerce] order number '. $order->get_order_number() );
+		error_log( '[sift-for-woocommerce] order number ' . $order->get_order_number() );
 
 		if ( ! in_array( $order->get_status(), self::SUPPORTED_WOO_ORDER_STATUS_CHANGES, true ) ) {
 			return;
@@ -1098,7 +1098,15 @@ class Events {
 		error_log( '[sift-for-woocommerce] filtered payment methods while getting customer payment methods:' );
 		error_log( print_r( $payment_methods, true ) );
 
-		$payment_methods = array_filter( $payment_methods, fn( $payment_method ) => ! empty( $payment_method ) && ! in_array( $payment_method, $payment_methods, true ) );
+		$payment_methods = array_reduce(
+			$payment_methods,
+			function ( $payment_methods, $payment_method ) {
+				if ( ! empty( $payment_method ) && ! in_array( $payment_method, $payment_methods, true ) ) {
+					$payment_methods[] = $payment_method;
+				}
+				return $payment_methods;
+			}
+		);
 		error_log( '[sift-for-woocommerce] reduced filtered payment methods while getting customer payment methods:' );
 		error_log( print_r( $payment_methods, true ) );
 

--- a/src/sift-for-woocommerce.php
+++ b/src/sift-for-woocommerce.php
@@ -20,6 +20,8 @@ defined( 'ABSPATH' ) || exit;
  */
 class Sift_For_WooCommerce {
 
+	private static $sift_orders = array();
+
 	// region MAGIC METHODS
 
 	/**
@@ -130,6 +132,21 @@ class Sift_For_WooCommerce {
 		}
 
 		return $client;
+	}
+
+	/**
+	 * Get a Sift_Order object from a WC_Order object.
+	 * Allows a small speed up in performance due to caching the orders.
+	 *
+	 * @param \WC_Order $order The WC_Order object.
+	 *
+	 * @return Sift_Order The Sift_Order object.
+	 */
+	public static function get_sift_order_from_wc_order( \WC_Order $order ): Sift_Order {
+		if ( ! array_key_exists( $order->get_order_key(), static::$sift_orders ) ) {
+			static::$sift_orders[ $order->get_order_key() ] = new Sift_Order( $order );
+		}
+		return static::$sift_orders[ $order->get_order_key() ];
 	}
 
 	// endregion


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds customer payment methods by enumerating over a customer's order and acquiring the payment method for each.
* Removes duplicate payment methods before sending.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this branch to an environment with multiple payment methods.
* Update the account of a user with multiple payment methods.
* Confirm the payment methods for `$update_account` is correct.
* Try a purchase as a new user and confirm that `$create_account` is correct.

Mentions # 554-gh-automattic/gold
