### PR TITLE
Fix mistyped option

### DIFF
--- a/src/inc/tracking-js.php
+++ b/src/inc/tracking-js.php
@@ -14,7 +14,7 @@ function print_sift_tracking_js() {
 		return null;
 	}
 
-	$beacon_key = get_option( 'wc_sift_for_woocommerce_beacon_key' );
+	$beacon_key = get_option( 'wc_sift_for_woocommerce_sift_beacon_key' );
 	if ( ! $beacon_key ) {
 		return null;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `wc_sift_for_woocommerce_sift_beacon_key` was missing the last `sift`, so no JS was added.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #
