### PR TITLE
Instanciate after plugins_loaded

### DIFF
--- a/sift-for-woocommerce.php
+++ b/sift-for-woocommerce.php
@@ -56,4 +56,9 @@ require_once __DIR__ . '/vendor/autoload.php';
 
 require_once __DIR__ . '/src/sift-for-woocommerce.php';
 
-\Sift_For_WooCommerce\Sift_For_WooCommerce::get_instance();
+add_action(
+	'plugins_loaded',
+	function () {
+		\Sift_For_WooCommerce\Sift_For_WooCommerce::get_instance();
+	}
+);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Allows sidecar plugins to load after via the filter after the the filter has been defined (plugin loaded).

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use this trunk with an installation that uses a sidecar plugin.
* Confirm the sidecar plugin loads correctly

Mentions #571-gh-automattic/gold
