### PR TITLE
Fix PHP Warnings in PPCP Gateway

### DIFF
--- a/src/inc/payment-gateways/ppcp-gateway.php
+++ b/src/inc/payment-gateways/ppcp-gateway.php
@@ -56,6 +56,7 @@ function get_from_order( $value, \WC_Order $order ) {
  *
  * @param mixed    $selectable The thing to be selected from. Usually this would be an object or array but it could be anything.
  * @param function $selector   The function which takes `$selectable` as its input, performs an operation and returns the result.
+ *
  * @return mixed|null
  */
 function select_first( $selectable, $selector ) {
@@ -77,6 +78,7 @@ function select_first( $selectable, $selector ) {
  * Select the first purchase unit or null if it could not be selected.
  *
  * @param WooCommerce\PayPalCommerce\ApiClient\Entity\Order $ppcp_data_order The PayPal Order object.
+ *
  * @return WooCommerce\PayPalCommerce\ApiClient\Entity\PurchaseUnit|null The resulting PurchaseUnit if one is found.
  */
 function select_first_purchase_unit( $ppcp_data_order ) {
@@ -90,6 +92,7 @@ function select_first_purchase_unit( $ppcp_data_order ) {
  * Select the first payments authorization or null if it could not be selected.
  *
  * @param WooCommerce\PayPalCommerce\ApiClient\Entity\Order $ppcp_data_order The PayPal Order object.
+ *
  * @return WooCommerce\PayPalCommerce\ApiClient\Entity\Authorization|null The resulting Authorization if one is found.
  */
 function select_first_payments_authorization( $ppcp_data_order ) {
@@ -102,7 +105,8 @@ function select_first_payments_authorization( $ppcp_data_order ) {
 /**
  * Select the first payments caputure or null if it could not be selected.
  *
- * @param WooCommerce\PayPalCommerce\ApiClient\Entity\Order $ppcp_data_order The PayPal Order object.
+ * @param WooCommerce\PayPalCommerce\ApiClient\Entity\Order $ppcp_data_order The PayPal Order object
+ *
  * @return WooCommerce\PayPalCommerce\ApiClient\Entity\Capture|null The resulting Capture if one is found.
  */
 function select_first_payments_capture( $ppcp_data_order ) {

--- a/src/inc/payment-gateways/ppcp-gateway.php
+++ b/src/inc/payment-gateways/ppcp-gateway.php
@@ -54,8 +54,9 @@ function get_from_order( $value, \WC_Order $order ) {
  *
  * $a = select_first( $b, fn( $o ) => $o->c() )?->d();
  *
- * @param mixed $selectable  The thing to be selected from. Usually this would be an object or array but it could be anything.
- * @param function $selector The function which takes `$selectable` as its input, performs an operation and returns the result.
+ * @param mixed    $selectable The thing to be selected from. Usually this would be an object or array but it could be anything.
+ * @param function $selector   The function which takes `$selectable` as its input, performs an operation and returns the result.
+ * @return mixed|null
  */
 function select_first( $selectable, $selector ) {
 	try {
@@ -75,8 +76,8 @@ function select_first( $selectable, $selector ) {
 /**
  * Select the first purchase unit or null if it could not be selected.
  *
- * @param WooCommerce\PayPalCommerce\ApiClient\Entity\Order $ppcp_data_order The PayPal Order object
- * @return WooCommerce\PayPalCommerce\ApiClient\Entity\PurchaseUnit|null The resulting PurchaseUnit if one is found
+ * @param WooCommerce\PayPalCommerce\ApiClient\Entity\Order $ppcp_data_order The PayPal Order object.
+ * @return WooCommerce\PayPalCommerce\ApiClient\Entity\PurchaseUnit|null The resulting PurchaseUnit if one is found.
  */
 function select_first_purchase_unit( $ppcp_data_order ) {
 	return select_first(
@@ -88,8 +89,8 @@ function select_first_purchase_unit( $ppcp_data_order ) {
 /**
  * Select the first payments authorization or null if it could not be selected.
  *
- * @param WooCommerce\PayPalCommerce\ApiClient\Entity\Order $ppcp_data_order The PayPal Order object
- * @return WooCommerce\PayPalCommerce\ApiClient\Entity\Authorization|null The resulting Authorization if one is found
+ * @param WooCommerce\PayPalCommerce\ApiClient\Entity\Order $ppcp_data_order The PayPal Order object.
+ * @return WooCommerce\PayPalCommerce\ApiClient\Entity\Authorization|null The resulting Authorization if one is found.
  */
 function select_first_payments_authorization( $ppcp_data_order ) {
 	return select_first(
@@ -101,8 +102,8 @@ function select_first_payments_authorization( $ppcp_data_order ) {
 /**
  * Select the first payments caputure or null if it could not be selected.
  *
- * @param WooCommerce\PayPalCommerce\ApiClient\Entity\Order $ppcp_data_order The PayPal Order object
- * @return WooCommerce\PayPalCommerce\ApiClient\Entity\Capture|null The resulting Capture if one is found
+ * @param WooCommerce\PayPalCommerce\ApiClient\Entity\Order $ppcp_data_order The PayPal Order object.
+ * @return WooCommerce\PayPalCommerce\ApiClient\Entity\Capture|null The resulting Capture if one is found.
  */
 function select_first_payments_capture( $ppcp_data_order ) {
 	return select_first(

--- a/src/inc/payment-gateways/ppcp-gateway.php
+++ b/src/inc/payment-gateways/ppcp-gateway.php
@@ -105,7 +105,7 @@ function select_first_payments_authorization( $ppcp_data_order ) {
 /**
  * Select the first payments caputure or null if it could not be selected.
  *
- * @param WooCommerce\PayPalCommerce\ApiClient\Entity\Order $ppcp_data_order The PayPal Order object
+ * @param WooCommerce\PayPalCommerce\ApiClient\Entity\Order $ppcp_data_order The PayPal Order object.
  *
  * @return WooCommerce\PayPalCommerce\ApiClient\Entity\Capture|null The resulting Capture if one is found.
  */


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove a PHP Warning that happens when a function returns null and we expect an array.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Patch this to your installed plugin
* Try triggering this warning by updating the account page for a user with PayPal payment methods, or by trying to purchase something with PayPal.

Alternatively, automated tests should cover this already.

Closes 602-gh-automattic/gold
