### PR TITLE
Add `woocommerce-com` as the `product_channel` for orders

### DIFF
--- a/src/inc/sift-events/sift-events.php
+++ b/src/inc/sift-events/sift-events.php
@@ -626,6 +626,7 @@ class Events {
 			'$site_country'    => wc_get_base_location()['country'],
 			'$ip'              => self::get_client_ip(),
 			'$time'            => intval( 1000 * microtime( true ) ),
+			'product_channel'  => 'woocommerce-com',
 		);
 
 		// Add the user_id only if a user exists, otherwise, let it remain empty.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This adds `woocommerce-com` as the `product_channel` for orders, as requested in p1737043242305869-slack-C05U537T5CK

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a test order on the SFW environment.
* Check the sift sandbox MOR instance for the `$create_order` event, and look for `product_channel` and ensure it's `woocommerce-com`.

![Screenshot 2025-01-16 at 10 53 06 PM](https://github.com/user-attachments/assets/0e5a97f8-d08f-437e-b26f-5f1710bc500d)

Mentions #