### PR TITLE
Remove verification status and add test coverage for ppcp-gateway

### DIFF
--- a/src/inc/payment-gateways/ppcp-gateway.php
+++ b/src/inc/payment-gateways/ppcp-gateway.php
@@ -124,7 +124,6 @@ add_filter( 'sift_for_woocommerce_ppcp-gateway_payment_type_string', fn( $value,
 add_filter( 'sift_for_woocommerce_ppcp-gateway_card_last4', fn( $value, $ppcp_data ) => $ppcp_data['wc_order']?->get_meta_data( PayPalGateway::FRAUD_RESULT_META_KEY )['card_last_digits'] ?? $value, 10, 2 );
 add_filter( 'sift_for_woocommerce_ppcp-gateway_avs_result_code', fn( $value, $ppcp_data ) => select_first_payments_authorization( $ppcp_data['order'] )?->fraud_processor_response()->avs_code() ?? $value, 10, 2 );
 add_filter( 'sift_for_woocommerce_ppcp-gateway_cvv_result_code', fn( $value, $ppcp_data ) => select_first_payments_authorization( $ppcp_data['order'] )?->fraud_processor_response()->cvv_code() ?? $value, 10, 2 );
-add_filter( 'sift_for_woocommerce_ppcp-gateway_verification_status', fn( $value, $ppcp_data ) => select_first_payments_authorization( $ppcp_data['order'] )?->status()->name() ?? $value, 10, 2 );
 add_filter( 'sift_for_woocommerce_ppcp-gateway_decline_reason_code', fn( $value, $ppcp_data ) => select_first_payments_authorization( $ppcp_data['order'] )?->to_array()['reason_code'] ?? $value, 10, 2 );
 
 add_filter( 'sift_for_woocommerce_ppcp-gateway_paypal_payer_id', fn( $value, $ppcp_data ) => $ppcp_data['order']?->payer()?->payer_id() ?? $value, 10, 2 );

--- a/tests/PaymentMethodTest.php
+++ b/tests/PaymentMethodTest.php
@@ -5,6 +5,7 @@ namespace Sift_For_WooCommerce\Tests;
 use Sift_For_WooCommerce\Sift_Payment_Gateway;
 use Sift_For_WooCommerce\Sift_Payment_Method;
 
+use function Sift_For_WooCommerce\Tests\Mocks\Utils\build_mock_ppcp_order_object;
 use function Sift_For_WooCommerce\Tests\Mocks\Utils\build_mock_stripe_payment_method_object;
 
 require_once __DIR__ . '/../src/inc/sift-events/normalizers/sift-payment-gateway.php';
@@ -13,6 +14,7 @@ require_once __DIR__ . '/../src/inc/payment-gateways/lib/stripe.php';
 require_once __DIR__ . '/../src/inc/payment-gateways/stripe.php';
 require_once __DIR__ . '/../src/inc/payment-gateways/transact.php';
 require_once __DIR__ . '/../src/inc/payment-gateways/woocommerce-payments.php';
+require_once __DIR__ . '/../src/inc/payment-gateways/ppcp-gateway.php';
 require_once __DIR__ . '/mocks/utils.php';
 
 /**
@@ -122,9 +124,14 @@ class PaymentMethodTest extends \WP_UnitTestCase {
 			true
 		);
 		$order                               = new \WC_Order();
+		$ppcp_order_data = array(
+			'wc_order' => $order,
+			'order' => build_mock_ppcp_order_object(),
+		);
 		$stripe_gateway                      = new Sift_Payment_Gateway( 'stripe', $order );
 		$transact_gateway                    = new Sift_Payment_Gateway( 'transact', $order );
 		$woocommerce_payments_gateway        = new Sift_Payment_Gateway( 'woocommerce_payments', $order );
+		$ppcp_gateway                 = new Sift_Payment_Gateway( 'ppcp-gateway', $order );
 		return array(
 			'Stripe\'s object returns the card_bin property' => array(
 				'gateway'  => $stripe_gateway,
@@ -141,6 +148,70 @@ class PaymentMethodTest extends \WP_UnitTestCase {
 				'data'     => $woocommerce_payments_payment_method,
 				'expected' => $woocommerce_payments_card_bin,
 			),
+			'PayPal\'s object does not return the card_bin property' => array(
+				'gateway'  => $ppcp_gateway,
+				'data'     => $ppcp_order_data,
+				'expected' => '',
+			)
+		);
+	}
+
+	/**
+	 * Test getting the avs_result_code property.
+	 *
+	 * @dataProvider get_avs_result_code_provider
+	 *
+	 * @param Sift_Payment_Gateway $gateway  The payment gateway in use.
+	 * @param mixed                $data     The data which contains the avs_result_code value.
+	 * @param null|string          $expected The expected result if available.
+	 *
+	 * @return void
+	 */
+	public function test_get_avs_result_code( Sift_Payment_Gateway $gateway, mixed $data, ?string $expected ) {
+		$result = Sift_Payment_Method::get_avs_result_code( $gateway, $data );
+		$this->assertEquals( $expected, $result, 'Should return the expected result' );
+	}
+
+	/**
+	 * Provide data to the test_get_avs_result_code test function.
+	 *
+	 * @return array An array of test runs and the data associated with each run.
+	 */
+	public function get_avs_result_code_provider(): array {
+		$order                        = new \WC_Order();
+		$stripe_charge                = (object) array(
+			'payment_method_details' => build_mock_stripe_payment_method_object( array() ),
+		);
+		$ppcp_order_data = array(
+			'wc_order' => $order,
+			'order' => build_mock_ppcp_order_object(),
+		);
+		$woocommerce_payments_charge  = array( 'payment_method_details' => build_mock_stripe_payment_method_object( array(), true ) );
+		$stripe_gateway               = new Sift_Payment_Gateway( 'stripe', $order );
+		$transact_gateway             = new Sift_Payment_Gateway( 'transact', $order );
+		$woocommerce_payments_gateway = new Sift_Payment_Gateway( 'woocommerce_payments', $order );
+		$ppcp_gateway                 = new Sift_Payment_Gateway( 'ppcp-gateway', $order );
+		return array(
+			'Stripe\'s object does not return the avs_result_code property' => array(
+				'gateway'  => $stripe_gateway,
+				'data'     => $stripe_charge,
+				'expected' => '',
+			),
+			'Transact\'s object does not return the avs_result_code property' => array(
+				'gateway'  => $transact_gateway,
+				'data'     => $order,
+				'expected' => '',
+			),
+			'WooCommerce Payments\'s object does not return the avs_result_code property' => array(
+				'gateway'  => $woocommerce_payments_gateway,
+				'data'     => $woocommerce_payments_charge,
+				'expected' => '',
+			),
+			'PayPal\'s object returns the avs_result_code property' => array(
+				'gateway'  => $ppcp_gateway,
+				'data'     => $ppcp_order_data,
+				'expected' => 'AVS-OK',
+			)
 		);
 	}
 
@@ -166,14 +237,19 @@ class PaymentMethodTest extends \WP_UnitTestCase {
 	 * @return array An array of test runs and the data associated with each run.
 	 */
 	public function get_cvv_result_code_provider(): array {
+		$order                        = new \WC_Order();
 		$stripe_charge                = (object) array(
 			'payment_method_details' => build_mock_stripe_payment_method_object( array() ),
 		);
+		$ppcp_order_data = array(
+			'wc_order' => $order,
+			'order' => build_mock_ppcp_order_object(),
+		);
 		$woocommerce_payments_charge  = array( 'payment_method_details' => build_mock_stripe_payment_method_object( array(), true ) );
-		$order                        = new \WC_Order();
 		$stripe_gateway               = new Sift_Payment_Gateway( 'stripe', $order );
 		$transact_gateway             = new Sift_Payment_Gateway( 'transact', $order );
 		$woocommerce_payments_gateway = new Sift_Payment_Gateway( 'woocommerce_payments', $order );
+		$ppcp_gateway                 = new Sift_Payment_Gateway( 'ppcp-gateway', $order );
 		return array(
 			'Stripe\'s object returns the cvv_result_code property' => array(
 				'gateway'  => $stripe_gateway,
@@ -190,6 +266,306 @@ class PaymentMethodTest extends \WP_UnitTestCase {
 				'data'     => $woocommerce_payments_charge,
 				'expected' => 'OK',
 			),
+			'PayPal\'s object returns the cvv_result_code property' => array(
+				'gateway'  => $ppcp_gateway,
+				'data'     => $ppcp_order_data,
+				'expected' => 'CVV-OK',
+			)
+		);
+	}
+
+	/**
+	 * Test getting the decline_reason_code property.
+	 *
+	 * @dataProvider get_decline_reason_code_provider
+	 *
+	 * @param Sift_Payment_Gateway $gateway  The payment gateway in use.
+	 * @param mixed                $data     The data which contains the decline_reason_code value.
+	 * @param null|string          $expected The expected result if available.
+	 *
+	 * @return void
+	 */
+	public function test_get_decline_reason_code( Sift_Payment_Gateway $gateway, mixed $data, ?string $expected ) {
+		$result = Sift_Payment_Method::get_decline_reason_code( $gateway, $data );
+		$this->assertEquals( $expected, $result, 'Should return the expected result' );
+	}
+
+	/**
+	 * Provide data to the test_get_decline_reason_code test function.
+	 *
+	 * @return array An array of test runs and the data associated with each run.
+	 */
+	public function get_decline_reason_code_provider(): array {
+		$order                        = new \WC_Order();
+		$stripe_charge                = (object) array(
+			'payment_method_details' => build_mock_stripe_payment_method_object( array() ),
+		);
+		$ppcp_order_data = array(
+			'wc_order' => $order,
+			'order' => build_mock_ppcp_order_object(),
+		);
+		$woocommerce_payments_charge  = array( 'payment_method_details' => build_mock_stripe_payment_method_object( array(), true ) );
+		$stripe_gateway               = new Sift_Payment_Gateway( 'stripe', $order );
+		$transact_gateway             = new Sift_Payment_Gateway( 'transact', $order );
+		$woocommerce_payments_gateway = new Sift_Payment_Gateway( 'woocommerce_payments', $order );
+		$ppcp_gateway                 = new Sift_Payment_Gateway( 'ppcp-gateway', $order );
+		return array(
+			'Stripe\'s object does not return the decline_reason_code property' => array(
+				'gateway'  => $stripe_gateway,
+				'data'     => $stripe_charge,
+				'expected' => '',
+			),
+			'Transact\'s object does not return the decline_reason_code property' => array(
+				'gateway'  => $transact_gateway,
+				'data'     => $order,
+				'expected' => '',
+			),
+			'WooCommerce Payments\'s does not object return the decline_reason_code property' => array(
+				'gateway'  => $woocommerce_payments_gateway,
+				'data'     => $woocommerce_payments_charge,
+				'expected' => '',
+			),
+			'PayPal\'s object returns the decline_reason_code property' => array(
+				'gateway'  => $ppcp_gateway,
+				'data'     => $ppcp_order_data,
+				'expected' => 'PPCP-decline-reason-code',
+			)
+		);
+	}
+
+	/**
+	 * Test getting the paypal_payer_id property.
+	 *
+	 * @dataProvider get_paypal_payer_id_provider
+	 *
+	 * @param Sift_Payment_Gateway $gateway  The payment gateway in use.
+	 * @param mixed                $data     The data which contains the paypal_payer_id value.
+	 * @param null|string          $expected The expected result if available.
+	 *
+	 * @return void
+	 */
+	public function test_get_paypal_payer_id( Sift_Payment_Gateway $gateway, mixed $data, ?string $expected ) {
+		$result = Sift_Payment_Method::get_paypal_payer_id( $gateway, $data );
+		$this->assertEquals( $expected, $result, 'Should return the expected result' );
+	}
+
+	/**
+	 * Provide data to the test_get_paypal_payer_id test function.
+	 *
+	 * @return array An array of test runs and the data associated with each run.
+	 */
+	public function get_paypal_payer_id_provider(): array {
+		$order                        = new \WC_Order();
+		$stripe_charge                = (object) array(
+			'payment_method_details' => build_mock_stripe_payment_method_object( array() ),
+		);
+		$ppcp_order_data = array(
+			'wc_order' => $order,
+			'order' => build_mock_ppcp_order_object(),
+		);
+		$woocommerce_payments_charge  = array( 'payment_method_details' => build_mock_stripe_payment_method_object( array(), true ) );
+		$stripe_gateway               = new Sift_Payment_Gateway( 'stripe', $order );
+		$transact_gateway             = new Sift_Payment_Gateway( 'transact', $order );
+		$woocommerce_payments_gateway = new Sift_Payment_Gateway( 'woocommerce_payments', $order );
+		$ppcp_gateway                 = new Sift_Payment_Gateway( 'ppcp-gateway', $order );
+		return array(
+			'Stripe\'s object does not return the paypal_payer_id property' => array(
+				'gateway'  => $stripe_gateway,
+				'data'     => $stripe_charge,
+				'expected' => '',
+			),
+			'Transact\'s object does not return the paypal_payer_id property' => array(
+				'gateway'  => $transact_gateway,
+				'data'     => $order,
+				'expected' => '',
+			),
+			'WooCommerce Payments\'s does not object return the paypal_payer_id property' => array(
+				'gateway'  => $woocommerce_payments_gateway,
+				'data'     => $woocommerce_payments_charge,
+				'expected' => '',
+			),
+			'PayPal\'s object returns the paypal_payer_id property' => array(
+				'gateway'  => $ppcp_gateway,
+				'data'     => $ppcp_order_data,
+				'expected' => 'PPCP-Payer-ID',
+			)
+		);
+	}
+
+	/**
+	 * Test getting the paypal_payer_email property.
+	 *
+	 * @dataProvider get_paypal_payer_email_provider
+	 *
+	 * @param Sift_Payment_Gateway $gateway  The payment gateway in use.
+	 * @param mixed                $data     The data which contains the paypal_payer_email value.
+	 * @param null|string          $expected The expected result if available.
+	 *
+	 * @return void
+	 */
+	public function test_get_paypal_payer_email( Sift_Payment_Gateway $gateway, mixed $data, ?string $expected ) {
+		$result = Sift_Payment_Method::get_paypal_payer_email( $gateway, $data );
+		$this->assertEquals( $expected, $result, 'Should return the expected result' );
+	}
+
+	/**
+	 * Provide data to the test_get_paypal_payer_email test function.
+	 *
+	 * @return array An array of test runs and the data associated with each run.
+	 */
+	public function get_paypal_payer_email_provider(): array {
+		$order                        = new \WC_Order();
+		$stripe_charge                = (object) array(
+			'payment_method_details' => build_mock_stripe_payment_method_object( array() ),
+		);
+		$ppcp_order_data = array(
+			'wc_order' => $order,
+			'order' => build_mock_ppcp_order_object(),
+		);
+		$woocommerce_payments_charge  = array( 'payment_method_details' => build_mock_stripe_payment_method_object( array(), true ) );
+		$stripe_gateway               = new Sift_Payment_Gateway( 'stripe', $order );
+		$transact_gateway             = new Sift_Payment_Gateway( 'transact', $order );
+		$woocommerce_payments_gateway = new Sift_Payment_Gateway( 'woocommerce_payments', $order );
+		$ppcp_gateway                 = new Sift_Payment_Gateway( 'ppcp-gateway', $order );
+		return array(
+			'Stripe\'s object does not return the paypal_payer_email property' => array(
+				'gateway'  => $stripe_gateway,
+				'data'     => $stripe_charge,
+				'expected' => '',
+			),
+			'Transact\'s object does not return the paypal_payer_email property' => array(
+				'gateway'  => $transact_gateway,
+				'data'     => $order,
+				'expected' => '',
+			),
+			'WooCommerce Payments\'s does not object return the paypal_payer_email property' => array(
+				'gateway'  => $woocommerce_payments_gateway,
+				'data'     => $woocommerce_payments_charge,
+				'expected' => '',
+			),
+			'PayPal\'s object returns the paypal_payer_email property' => array(
+				'gateway'  => $ppcp_gateway,
+				'data'     => $ppcp_order_data,
+				'expected' => 'payer@example.org',
+			)
+		);
+	}
+
+	/**
+	 * Test getting the paypal_protection_eligibility property.
+	 *
+	 * @dataProvider get_paypal_protection_eligibility_provider
+	 *
+	 * @param Sift_Payment_Gateway $gateway  The payment gateway in use.
+	 * @param mixed                $data     The data which contains the paypal_protection_eligibility value.
+	 * @param null|string          $expected The expected result if available.
+	 *
+	 * @return void
+	 */
+	public function test_get_paypal_protection_eligibility( Sift_Payment_Gateway $gateway, mixed $data, ?string $expected ) {
+		$result = Sift_Payment_Method::get_paypal_protection_eligibility( $gateway, $data );
+		$this->assertEquals( $expected, $result, 'Should return the expected result' );
+	}
+
+	/**
+	 * Provide data to the test_get_paypal_protection_eligibility test function.
+	 *
+	 * @return array An array of test runs and the data associated with each run.
+	 */
+	public function get_paypal_protection_eligibility_provider(): array {
+		$order                        = new \WC_Order();
+		$stripe_charge                = (object) array(
+			'payment_method_details' => build_mock_stripe_payment_method_object( array() ),
+		);
+		$ppcp_order_data = array(
+			'wc_order' => $order,
+			'order' => build_mock_ppcp_order_object(),
+		);
+		$woocommerce_payments_charge  = array( 'payment_method_details' => build_mock_stripe_payment_method_object( array(), true ) );
+		$stripe_gateway               = new Sift_Payment_Gateway( 'stripe', $order );
+		$transact_gateway             = new Sift_Payment_Gateway( 'transact', $order );
+		$woocommerce_payments_gateway = new Sift_Payment_Gateway( 'woocommerce_payments', $order );
+		$ppcp_gateway                 = new Sift_Payment_Gateway( 'ppcp-gateway', $order );
+		return array(
+			'Stripe\'s object does not return the paypal_protection_eligibility property' => array(
+				'gateway'  => $stripe_gateway,
+				'data'     => $stripe_charge,
+				'expected' => '',
+			),
+			'Transact\'s object does not return the paypal_protection_eligibility property' => array(
+				'gateway'  => $transact_gateway,
+				'data'     => $order,
+				'expected' => '',
+			),
+			'WooCommerce Payments\'s does not object return the paypal_protection_eligibility property' => array(
+				'gateway'  => $woocommerce_payments_gateway,
+				'data'     => $woocommerce_payments_charge,
+				'expected' => '',
+			),
+			'PayPal\'s object returns the paypal_protection_eligibility property' => array(
+				'gateway'  => $ppcp_gateway,
+				'data'     => $ppcp_order_data,
+				'expected' => 'PPCP-seller-protection-status',
+			)
+		);
+	}
+
+	/**
+	 * Test getting the paypal_payment_status property.
+	 *
+	 * @dataProvider get_paypal_payment_status_provider
+	 *
+	 * @param Sift_Payment_Gateway $gateway  The payment gateway in use.
+	 * @param mixed                $data     The data which contains the paypal_payment_status value.
+	 * @param null|string          $expected The expected result if available.
+	 *
+	 * @return void
+	 */
+	public function test_get_paypal_payment_status( Sift_Payment_Gateway $gateway, mixed $data, ?string $expected ) {
+		$result = Sift_Payment_Method::get_paypal_payment_status( $gateway, $data );
+		$this->assertEquals( $expected, $result, 'Should return the expected result' );
+	}
+
+	/**
+	 * Provide data to the test_get_paypal_payment_status test function.
+	 *
+	 * @return array An array of test runs and the data associated with each run.
+	 */
+	public function get_paypal_payment_status_provider(): array {
+		$order                        = new \WC_Order();
+		$stripe_charge                = (object) array(
+			'payment_method_details' => build_mock_stripe_payment_method_object( array() ),
+		);
+		$ppcp_order_data = array(
+			'wc_order' => $order,
+			'order' => build_mock_ppcp_order_object(),
+		);
+		$woocommerce_payments_charge  = array( 'payment_method_details' => build_mock_stripe_payment_method_object( array(), true ) );
+		$stripe_gateway               = new Sift_Payment_Gateway( 'stripe', $order );
+		$transact_gateway             = new Sift_Payment_Gateway( 'transact', $order );
+		$woocommerce_payments_gateway = new Sift_Payment_Gateway( 'woocommerce_payments', $order );
+		$ppcp_gateway                 = new Sift_Payment_Gateway( 'ppcp-gateway', $order );
+		return array(
+			'Stripe\'s object does not return the paypal_payment_status property' => array(
+				'gateway'  => $stripe_gateway,
+				'data'     => $stripe_charge,
+				'expected' => '',
+			),
+			'Transact\'s object does not return the paypal_payment_status property' => array(
+				'gateway'  => $transact_gateway,
+				'data'     => $order,
+				'expected' => '',
+			),
+			'WooCommerce Payments\'s does not object return the paypal_payment_status property' => array(
+				'gateway'  => $woocommerce_payments_gateway,
+				'data'     => $woocommerce_payments_charge,
+				'expected' => '',
+			),
+			'PayPal\'s object returns the paypal_payment_status property' => array(
+				'gateway'  => $ppcp_gateway,
+				'data'     => $ppcp_order_data,
+				'expected' => 'PPCP-capture-status',
+			)
 		);
 	}
 

--- a/tests/PaymentMethodTest.php
+++ b/tests/PaymentMethodTest.php
@@ -124,14 +124,14 @@ class PaymentMethodTest extends \WP_UnitTestCase {
 			true
 		);
 		$order                               = new \WC_Order();
-		$ppcp_order_data = array(
+		$ppcp_order_data                     = array(
 			'wc_order' => $order,
-			'order' => build_mock_ppcp_order_object(),
+			'order'    => build_mock_ppcp_order_object(),
 		);
 		$stripe_gateway                      = new Sift_Payment_Gateway( 'stripe', $order );
 		$transact_gateway                    = new Sift_Payment_Gateway( 'transact', $order );
 		$woocommerce_payments_gateway        = new Sift_Payment_Gateway( 'woocommerce_payments', $order );
-		$ppcp_gateway                 = new Sift_Payment_Gateway( 'ppcp-gateway', $order );
+		$ppcp_gateway                        = new Sift_Payment_Gateway( 'ppcp-gateway', $order );
 		return array(
 			'Stripe\'s object returns the card_bin property' => array(
 				'gateway'  => $stripe_gateway,
@@ -152,7 +152,7 @@ class PaymentMethodTest extends \WP_UnitTestCase {
 				'gateway'  => $ppcp_gateway,
 				'data'     => $ppcp_order_data,
 				'expected' => '',
-			)
+			),
 		);
 	}
 
@@ -182,9 +182,9 @@ class PaymentMethodTest extends \WP_UnitTestCase {
 		$stripe_charge                = (object) array(
 			'payment_method_details' => build_mock_stripe_payment_method_object( array() ),
 		);
-		$ppcp_order_data = array(
+		$ppcp_order_data              = array(
 			'wc_order' => $order,
-			'order' => build_mock_ppcp_order_object(),
+			'order'    => build_mock_ppcp_order_object(),
 		);
 		$woocommerce_payments_charge  = array( 'payment_method_details' => build_mock_stripe_payment_method_object( array(), true ) );
 		$stripe_gateway               = new Sift_Payment_Gateway( 'stripe', $order );
@@ -211,7 +211,7 @@ class PaymentMethodTest extends \WP_UnitTestCase {
 				'gateway'  => $ppcp_gateway,
 				'data'     => $ppcp_order_data,
 				'expected' => 'AVS-OK',
-			)
+			),
 		);
 	}
 
@@ -241,9 +241,9 @@ class PaymentMethodTest extends \WP_UnitTestCase {
 		$stripe_charge                = (object) array(
 			'payment_method_details' => build_mock_stripe_payment_method_object( array() ),
 		);
-		$ppcp_order_data = array(
+		$ppcp_order_data              = array(
 			'wc_order' => $order,
-			'order' => build_mock_ppcp_order_object(),
+			'order'    => build_mock_ppcp_order_object(),
 		);
 		$woocommerce_payments_charge  = array( 'payment_method_details' => build_mock_stripe_payment_method_object( array(), true ) );
 		$stripe_gateway               = new Sift_Payment_Gateway( 'stripe', $order );
@@ -270,7 +270,7 @@ class PaymentMethodTest extends \WP_UnitTestCase {
 				'gateway'  => $ppcp_gateway,
 				'data'     => $ppcp_order_data,
 				'expected' => 'CVV-OK',
-			)
+			),
 		);
 	}
 
@@ -300,9 +300,9 @@ class PaymentMethodTest extends \WP_UnitTestCase {
 		$stripe_charge                = (object) array(
 			'payment_method_details' => build_mock_stripe_payment_method_object( array() ),
 		);
-		$ppcp_order_data = array(
+		$ppcp_order_data              = array(
 			'wc_order' => $order,
-			'order' => build_mock_ppcp_order_object(),
+			'order'    => build_mock_ppcp_order_object(),
 		);
 		$woocommerce_payments_charge  = array( 'payment_method_details' => build_mock_stripe_payment_method_object( array(), true ) );
 		$stripe_gateway               = new Sift_Payment_Gateway( 'stripe', $order );
@@ -329,7 +329,7 @@ class PaymentMethodTest extends \WP_UnitTestCase {
 				'gateway'  => $ppcp_gateway,
 				'data'     => $ppcp_order_data,
 				'expected' => 'PPCP-decline-reason-code',
-			)
+			),
 		);
 	}
 
@@ -359,9 +359,9 @@ class PaymentMethodTest extends \WP_UnitTestCase {
 		$stripe_charge                = (object) array(
 			'payment_method_details' => build_mock_stripe_payment_method_object( array() ),
 		);
-		$ppcp_order_data = array(
+		$ppcp_order_data              = array(
 			'wc_order' => $order,
-			'order' => build_mock_ppcp_order_object(),
+			'order'    => build_mock_ppcp_order_object(),
 		);
 		$woocommerce_payments_charge  = array( 'payment_method_details' => build_mock_stripe_payment_method_object( array(), true ) );
 		$stripe_gateway               = new Sift_Payment_Gateway( 'stripe', $order );
@@ -388,7 +388,7 @@ class PaymentMethodTest extends \WP_UnitTestCase {
 				'gateway'  => $ppcp_gateway,
 				'data'     => $ppcp_order_data,
 				'expected' => 'PPCP-Payer-ID',
-			)
+			),
 		);
 	}
 
@@ -418,9 +418,9 @@ class PaymentMethodTest extends \WP_UnitTestCase {
 		$stripe_charge                = (object) array(
 			'payment_method_details' => build_mock_stripe_payment_method_object( array() ),
 		);
-		$ppcp_order_data = array(
+		$ppcp_order_data              = array(
 			'wc_order' => $order,
-			'order' => build_mock_ppcp_order_object(),
+			'order'    => build_mock_ppcp_order_object(),
 		);
 		$woocommerce_payments_charge  = array( 'payment_method_details' => build_mock_stripe_payment_method_object( array(), true ) );
 		$stripe_gateway               = new Sift_Payment_Gateway( 'stripe', $order );
@@ -447,7 +447,7 @@ class PaymentMethodTest extends \WP_UnitTestCase {
 				'gateway'  => $ppcp_gateway,
 				'data'     => $ppcp_order_data,
 				'expected' => 'payer@example.org',
-			)
+			),
 		);
 	}
 
@@ -477,9 +477,9 @@ class PaymentMethodTest extends \WP_UnitTestCase {
 		$stripe_charge                = (object) array(
 			'payment_method_details' => build_mock_stripe_payment_method_object( array() ),
 		);
-		$ppcp_order_data = array(
+		$ppcp_order_data              = array(
 			'wc_order' => $order,
-			'order' => build_mock_ppcp_order_object(),
+			'order'    => build_mock_ppcp_order_object(),
 		);
 		$woocommerce_payments_charge  = array( 'payment_method_details' => build_mock_stripe_payment_method_object( array(), true ) );
 		$stripe_gateway               = new Sift_Payment_Gateway( 'stripe', $order );
@@ -506,7 +506,7 @@ class PaymentMethodTest extends \WP_UnitTestCase {
 				'gateway'  => $ppcp_gateway,
 				'data'     => $ppcp_order_data,
 				'expected' => 'PPCP-seller-protection-status',
-			)
+			),
 		);
 	}
 
@@ -536,9 +536,9 @@ class PaymentMethodTest extends \WP_UnitTestCase {
 		$stripe_charge                = (object) array(
 			'payment_method_details' => build_mock_stripe_payment_method_object( array() ),
 		);
-		$ppcp_order_data = array(
+		$ppcp_order_data              = array(
 			'wc_order' => $order,
-			'order' => build_mock_ppcp_order_object(),
+			'order'    => build_mock_ppcp_order_object(),
 		);
 		$woocommerce_payments_charge  = array( 'payment_method_details' => build_mock_stripe_payment_method_object( array(), true ) );
 		$stripe_gateway               = new Sift_Payment_Gateway( 'stripe', $order );
@@ -565,7 +565,7 @@ class PaymentMethodTest extends \WP_UnitTestCase {
 				'gateway'  => $ppcp_gateway,
 				'data'     => $ppcp_order_data,
 				'expected' => 'PPCP-capture-status',
-			)
+			),
 		);
 	}
 

--- a/tests/mocks/ppcp-gateway/PPCP_Mock_Authorization.php
+++ b/tests/mocks/ppcp-gateway/PPCP_Mock_Authorization.php
@@ -9,7 +9,7 @@ class PPCP_Mock_Authorization {
 	/**
 	 * Provide the fraud processor response.
 	 *
-	 * @return PPCP_Mock_Fraud_Processor_Response 
+	 * @return PPCP_Mock_Fraud_Processor_Response
 	 */
 	public function fraud_processor_response() {
 		return new PPCP_Mock_Fraud_Processor_Response();

--- a/tests/mocks/ppcp-gateway/PPCP_Mock_Authorization.php
+++ b/tests/mocks/ppcp-gateway/PPCP_Mock_Authorization.php
@@ -1,0 +1,17 @@
+<?php declare( strict_types=1 );
+
+namespace Sift_For_WooCommerce\Tests\Mocks\PPCP_Gateway;
+
+class PPCP_Mock_Authorization {
+	public function fraud_processor_response() {
+		return new PPCP_Mock_Fraud_Processor_Response();
+	}
+	public function status() {
+		return new PPCP_Mock_Authorization_Status();
+	}
+	public function to_array() {
+		return [
+			'reason_code' => 'PPCP-decline-reason-code',
+		];
+	}
+}

--- a/tests/mocks/ppcp-gateway/PPCP_Mock_Authorization.php
+++ b/tests/mocks/ppcp-gateway/PPCP_Mock_Authorization.php
@@ -2,16 +2,36 @@
 
 namespace Sift_For_WooCommerce\Tests\Mocks\PPCP_Gateway;
 
+/**
+ * Mock class that stores authorization related data.
+ */
 class PPCP_Mock_Authorization {
+	/**
+	 * Provide the fraud processor response.
+	 *
+	 * @return PPCP_Mock_Fraud_Processor_Response 
+	 */
 	public function fraud_processor_response() {
 		return new PPCP_Mock_Fraud_Processor_Response();
 	}
+
+	/**
+	 * Provide the status.
+	 *
+	 * @return PPCP_Mock_Authorization_Status
+	 */
 	public function status() {
 		return new PPCP_Mock_Authorization_Status();
 	}
+
+	/**
+	 * Return this class as an array
+	 *
+	 * @return array
+	 */
 	public function to_array() {
-		return [
+		return array(
 			'reason_code' => 'PPCP-decline-reason-code',
-		];
+		);
 	}
 }

--- a/tests/mocks/ppcp-gateway/PPCP_Mock_Authorization_Status.php
+++ b/tests/mocks/ppcp-gateway/PPCP_Mock_Authorization_Status.php
@@ -1,0 +1,9 @@
+<?php declare( strict_types=1 );
+
+namespace Sift_For_WooCommerce\Tests\Mocks\PPCP_Gateway;
+
+class PPCP_Mock_Authorization_Status {
+	public function name() {
+		return 'PPCP-authorization-status';
+	}
+}

--- a/tests/mocks/ppcp-gateway/PPCP_Mock_Authorization_Status.php
+++ b/tests/mocks/ppcp-gateway/PPCP_Mock_Authorization_Status.php
@@ -2,7 +2,15 @@
 
 namespace Sift_For_WooCommerce\Tests\Mocks\PPCP_Gateway;
 
+/**
+ * Mock object representing authorization status related data.
+ */
 class PPCP_Mock_Authorization_Status {
+	/**
+	 * Get the name.
+	 *
+	 * @return string
+	 */
 	public function name() {
 		return 'PPCP-authorization-status';
 	}

--- a/tests/mocks/ppcp-gateway/PPCP_Mock_Capture.php
+++ b/tests/mocks/ppcp-gateway/PPCP_Mock_Capture.php
@@ -2,11 +2,24 @@
 
 namespace Sift_For_WooCommerce\Tests\Mocks\PPCP_Gateway;
 
+/**
+ * Mock object that represents payments capture data
+ */
 class PPCP_Mock_Capture {
+	/**
+	 * Get the status.
+	 *
+	 * @return PPCP_Mock_Capture_Status
+	 */
 	public function status() {
 		return new PPCP_Mock_Capture_Status();
 	}
 
+	/**
+	 * Get the seller protection
+	 *
+	 * @return PPCP_Mock_Seller_Protection
+	 */
 	public function seller_protection() {
 		return new PPCP_Mock_Seller_Protection();
 	}

--- a/tests/mocks/ppcp-gateway/PPCP_Mock_Capture.php
+++ b/tests/mocks/ppcp-gateway/PPCP_Mock_Capture.php
@@ -1,0 +1,13 @@
+<?php declare( strict_types=1 );
+
+namespace Sift_For_WooCommerce\Tests\Mocks\PPCP_Gateway;
+
+class PPCP_Mock_Capture {
+	public function status() {
+		return new PPCP_Mock_Capture_Status();
+	}
+
+	public function seller_protection() {
+		return new PPCP_Mock_Seller_Protection();
+	}
+}

--- a/tests/mocks/ppcp-gateway/PPCP_Mock_Capture_Status.php
+++ b/tests/mocks/ppcp-gateway/PPCP_Mock_Capture_Status.php
@@ -1,0 +1,9 @@
+<?php declare( strict_types=1 );
+
+namespace Sift_For_WooCommerce\Tests\Mocks\PPCP_Gateway;
+
+class PPCP_Mock_Capture_Status {
+	public function name() {
+		return 'PPCP-capture-status';
+	}
+}

--- a/tests/mocks/ppcp-gateway/PPCP_Mock_Capture_Status.php
+++ b/tests/mocks/ppcp-gateway/PPCP_Mock_Capture_Status.php
@@ -2,7 +2,15 @@
 
 namespace Sift_For_WooCommerce\Tests\Mocks\PPCP_Gateway;
 
+/**
+ * Mock object that represents capture status.
+ */
 class PPCP_Mock_Capture_Status {
+	/**
+	 * Get the name of the status.
+	 *
+	 * @return string
+	 */
 	public function name() {
 		return 'PPCP-capture-status';
 	}

--- a/tests/mocks/ppcp-gateway/PPCP_Mock_Fraud_Processor_Response.php
+++ b/tests/mocks/ppcp-gateway/PPCP_Mock_Fraud_Processor_Response.php
@@ -2,10 +2,24 @@
 
 namespace Sift_For_WooCommerce\Tests\Mocks\PPCP_Gateway;
 
+/**
+ * Mock object that represents fraud processor response related information.
+ */
 class PPCP_Mock_Fraud_Processor_Response {
+	/**
+	 * Get the AVS code.
+	 *
+	 * @return string
+	 */
 	public function avs_code() {
 		return 'AVS-OK';
 	}
+
+	/**
+	 * Get the CVV code.
+	 * 
+	 * @return string
+	 */
 	public function cvv_code() {
 		return 'CVV-OK';
 	}

--- a/tests/mocks/ppcp-gateway/PPCP_Mock_Fraud_Processor_Response.php
+++ b/tests/mocks/ppcp-gateway/PPCP_Mock_Fraud_Processor_Response.php
@@ -1,0 +1,12 @@
+<?php declare( strict_types=1 );
+
+namespace Sift_For_WooCommerce\Tests\Mocks\PPCP_Gateway;
+
+class PPCP_Mock_Fraud_Processor_Response {
+	public function avs_code() {
+		return 'AVS-OK';
+	}
+	public function cvv_code() {
+		return 'CVV-OK';
+	}
+}

--- a/tests/mocks/ppcp-gateway/PPCP_Mock_Fraud_Processor_Response.php
+++ b/tests/mocks/ppcp-gateway/PPCP_Mock_Fraud_Processor_Response.php
@@ -17,7 +17,7 @@ class PPCP_Mock_Fraud_Processor_Response {
 
 	/**
 	 * Get the CVV code.
-	 * 
+	 *
 	 * @return string
 	 */
 	public function cvv_code() {

--- a/tests/mocks/ppcp-gateway/PPCP_Mock_Order.php
+++ b/tests/mocks/ppcp-gateway/PPCP_Mock_Order.php
@@ -2,10 +2,24 @@
 
 namespace Sift_For_WooCommerce\Tests\Mocks\PPCP_Gateway;
 
+/**
+ * Mock class that stores order related data.
+ */
 class PPCP_Mock_Order {
+	/**
+	 * Get the purchase_units array
+	 *
+	 * @return array
+	 */
 	public function purchase_units() {
-		return [ new PPCP_Mock_Purchase_Unit() ];
+		return array( new PPCP_Mock_Purchase_Unit() );
 	}
+
+	/**
+	 * Get the payer object.
+	 *
+	 * @return PPCP_Mock_Payer
+	 */
 	public function payer() {
 		return new PPCP_Mock_Payer();
 	}

--- a/tests/mocks/ppcp-gateway/PPCP_Mock_Order.php
+++ b/tests/mocks/ppcp-gateway/PPCP_Mock_Order.php
@@ -1,0 +1,12 @@
+<?php declare( strict_types=1 );
+
+namespace Sift_For_WooCommerce\Tests\Mocks\PPCP_Gateway;
+
+class PPCP_Mock_Order {
+	public function purchase_units() {
+		return [ new PPCP_Mock_Purchase_Unit() ];
+	}
+	public function payer() {
+		return new PPCP_Mock_Payer();
+	}
+}

--- a/tests/mocks/ppcp-gateway/PPCP_Mock_Payer.php
+++ b/tests/mocks/ppcp-gateway/PPCP_Mock_Payer.php
@@ -2,11 +2,24 @@
 
 namespace Sift_For_WooCommerce\Tests\Mocks\PPCP_Gateway;
 
+/**
+ * Mock object that represents payer related data.
+ */
 class PPCP_Mock_Payer {
+	/**
+	 * Get the payer id.
+	 *
+	 * @return string
+	 */
 	public function payer_id() {
 		return 'PPCP-Payer-ID';
 	}
 
+	/**
+	 * Get the payer's email address.
+	 *
+	 * @return string
+	 */
 	public function email_address() {
 		return 'payer@example.org';
 	}

--- a/tests/mocks/ppcp-gateway/PPCP_Mock_Payer.php
+++ b/tests/mocks/ppcp-gateway/PPCP_Mock_Payer.php
@@ -1,0 +1,13 @@
+<?php declare( strict_types=1 );
+
+namespace Sift_For_WooCommerce\Tests\Mocks\PPCP_Gateway;
+
+class PPCP_Mock_Payer {
+	public function payer_id() {
+		return 'PPCP-Payer-ID';
+	}
+
+	public function email_address() {
+		return 'payer@example.org';
+	}
+}

--- a/tests/mocks/ppcp-gateway/PPCP_Mock_Payments.php
+++ b/tests/mocks/ppcp-gateway/PPCP_Mock_Payments.php
@@ -2,11 +2,25 @@
 
 namespace Sift_For_WooCommerce\Tests\Mocks\PPCP_Gateway;
 
+/**
+ * Mock object representing payments related data.
+ */
 class PPCP_Mock_Payments {
+	/**
+	 * Get the payment captures.
+	 *
+	 * @return array
+	 */
 	public function captures() {
-		return [ new PPCP_Mock_Capture() ];
+		return array( new PPCP_Mock_Capture() );
 	}
+
+	/**
+	 * Get the payment authorizations.
+	 *
+	 * @return array
+	 */
 	public function authorizations() {
-		return [ new PPCP_Mock_Authorization() ];
+		return array( new PPCP_Mock_Authorization() );
 	}
 }

--- a/tests/mocks/ppcp-gateway/PPCP_Mock_Payments.php
+++ b/tests/mocks/ppcp-gateway/PPCP_Mock_Payments.php
@@ -1,0 +1,12 @@
+<?php declare( strict_types=1 );
+
+namespace Sift_For_WooCommerce\Tests\Mocks\PPCP_Gateway;
+
+class PPCP_Mock_Payments {
+	public function captures() {
+		return [ new PPCP_Mock_Capture() ];
+	}
+	public function authorizations() {
+		return [ new PPCP_Mock_Authorization() ];
+	}
+}

--- a/tests/mocks/ppcp-gateway/PPCP_Mock_Purchase_Unit.php
+++ b/tests/mocks/ppcp-gateway/PPCP_Mock_Purchase_Unit.php
@@ -2,7 +2,15 @@
 
 namespace Sift_For_WooCommerce\Tests\Mocks\PPCP_Gateway;
 
+/**
+ * Mock class that stores purchase unit related data.
+ */
 class PPCP_Mock_Purchase_Unit {
+	/**
+	 * Get the payments.
+	 *
+	 * @return PPCP_Mock_Payments
+	 */
 	public function payments() {
 		return new PPCP_Mock_Payments();
 	}

--- a/tests/mocks/ppcp-gateway/PPCP_Mock_Purchase_Unit.php
+++ b/tests/mocks/ppcp-gateway/PPCP_Mock_Purchase_Unit.php
@@ -1,0 +1,9 @@
+<?php declare( strict_types=1 );
+
+namespace Sift_For_WooCommerce\Tests\Mocks\PPCP_Gateway;
+
+class PPCP_Mock_Purchase_Unit {
+	public function payments() {
+		return new PPCP_Mock_Payments();
+	}
+}

--- a/tests/mocks/ppcp-gateway/PPCP_Mock_Seller_Protection.php
+++ b/tests/mocks/ppcp-gateway/PPCP_Mock_Seller_Protection.php
@@ -1,0 +1,7 @@
+<?php declare( strict_types=1 );
+
+namespace Sift_For_WooCommerce\Tests\Mocks\PPCP_Gateway;
+
+class PPCP_Mock_Seller_Protection {
+	public $status = 'PPCP-seller-protection-status';
+}

--- a/tests/mocks/ppcp-gateway/PPCP_Mock_Seller_Protection.php
+++ b/tests/mocks/ppcp-gateway/PPCP_Mock_Seller_Protection.php
@@ -2,6 +2,9 @@
 
 namespace Sift_For_WooCommerce\Tests\Mocks\PPCP_Gateway;
 
+/**
+ * Mock class that stores seller protection related data.
+ */
 class PPCP_Mock_Seller_Protection {
 	public $status = 'PPCP-seller-protection-status';
 }

--- a/tests/mocks/utils.php
+++ b/tests/mocks/utils.php
@@ -2,6 +2,19 @@
 
 namespace Sift_For_WooCommerce\Tests\Mocks\Utils;
 
+use Sift_For_WooCommerce\Tests\Mocks\PPCP_Gateway\PPCP_Mock_Order;
+
+require_once __DIR__ . '/ppcp-gateway/PPCP_Mock_Authorization.php';
+require_once __DIR__ . '/ppcp-gateway/PPCP_Mock_Authorization_Status.php';
+require_once __DIR__ . '/ppcp-gateway/PPCP_Mock_Capture.php';
+require_once __DIR__ . '/ppcp-gateway/PPCP_Mock_Capture_Status.php';
+require_once __DIR__ . '/ppcp-gateway/PPCP_Mock_Fraud_Processor_Response.php';
+require_once __DIR__ . '/ppcp-gateway/PPCP_Mock_Order.php';
+require_once __DIR__ . '/ppcp-gateway/PPCP_Mock_Payer.php';
+require_once __DIR__ . '/ppcp-gateway/PPCP_Mock_Payments.php';
+require_once __DIR__ . '/ppcp-gateway/PPCP_Mock_Purchase_Unit.php';
+require_once __DIR__ . '/ppcp-gateway/PPCP_Mock_Seller_Protection.php';
+
 /**
  * Build an object (or array) which represents the payment method returned by the Stripe API.
  *
@@ -51,4 +64,8 @@ function build_mock_stripe_payment_method_object( array $config, bool $as_array 
 			'mandate' => 'sepa direct debit mandate code',
 		),
 	);
+}
+
+function build_mock_ppcp_order_object(): object {
+	return new PPCP_Mock_Order();
 }

--- a/tests/mocks/utils.php
+++ b/tests/mocks/utils.php
@@ -66,6 +66,11 @@ function build_mock_stripe_payment_method_object( array $config, bool $as_array 
 	);
 }
 
+/**
+ * Build a mock order object from PPCP-Gateway
+ *
+ * @return PPCP_Mock_Order
+ */
 function build_mock_ppcp_order_object(): object {
 	return new PPCP_Mock_Order();
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove `$verification_status` from ppcp-gateway implementation - it was incorrect and I'm not sure right now what the correct field is.
* Add test coverage for ppcp-gateway payment method with mock classes.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Automated tests are included.

Mentions p1737531613946049/1737021980.939599-slack-C9J8248EB