### PR TITLE
Sift For WooCommerce: Correct price calculation

### DIFF
--- a/src/inc/sift-events/sift-events.php
+++ b/src/inc/sift-events/sift-events.php
@@ -1178,8 +1178,8 @@ class Events {
 			return intval( $price * 1000000 );
 		}
 
-		// For currencies with decimals
-		return intval( $price * 10000 );
+		// For currencies with decimals, we need to multiply times 100 (cents) to get the correct number.
+		return intval( $price * 100 * 10000 );
 	}
 
 	/**

--- a/src/inc/sift-events/sift-events.php
+++ b/src/inc/sift-events/sift-events.php
@@ -1170,16 +1170,8 @@ class Events {
 	 * @return integer
 	 */
 	public static function get_transaction_micros( float $price ) {
-		$currencies_without_decimals = array( 'JPY' );
-
-		$current_currency = get_woocommerce_currency();
-
-		if ( in_array( $current_currency, $currencies_without_decimals, true ) ) {
-			return intval( $price * 1000000 );
-		}
-
-		// For currencies with decimals, we need to multiply times 100 (cents) to get the correct number.
-		return intval( $price * 100 * 10000 );
+		// Sift expects the amount in micros, so we multiply by 1,000,000, regardless of the currency.
+		return intval( $price * 1000000 );
 	}
 
 	/**

--- a/tests/OrderStatusEventTest.php
+++ b/tests/OrderStatusEventTest.php
@@ -85,7 +85,7 @@ class OrderStatusEventTest extends EventTest {
 	public static function test_get_transaction_micros_based_on_currency() {
 		update_option( 'woocommerce_currency', 'USD' );
 
-		static::assertEquals( Events::get_transaction_micros( 39.00 ), 390000 );
+		static::assertEquals( Events::get_transaction_micros( 39.00 ), 39000000 );
 
 		update_option( 'woocommerce_currency', 'JPY' );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Sift requires that currencies with decimal (like USD) are sent in micros. We are currently calculating it incorrectly.

Even though Sift calls out zero decimal currency and implies a different calculation, we can simply multiply whatever number is sent to the function by 1000000. In their example, they multiply $1.23 * 10000, but are unclear that what the calculation really would be is $1.23 * 100 * 10000 to get the correct decimal placement in Sift.

This should mean that we can take whatever number is given to the method, and multiply it by 1000000, which tests out to be correct.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Start up the SFW dev environment, and ensure that you put in the API keys, etc into the Sift For WooCommerce settings for the MOR sandbox instance, if you don't already have those. Make sure you have at least $create_order and $transaction enabled.

2. Create a test order in your test environment.

3. Find the order in Sift; it should now show the correct price, and not one with a misplaced decimal (i.e., `$10.00` instead of `$.10`).

Fixes: https://github.com/Automattic/gold/issues/622
