### PR TITLE
Do not send removed items for products which no longer exist to Sift

### DIFF
--- a/src/inc/sift-events/sift-events.php
+++ b/src/inc/sift-events/sift-events.php
@@ -492,15 +492,14 @@ class Events {
 	 * @return void
 	 */
 	public static function remove_item_from_cart( string $cart_item_key, \WC_Cart $cart ) {
-
 		if ( ! Sift_Event_Types::can_event_be_sent( Sift_Event_Types::$remove_item_from_cart ) ) {
 			return;
 		}
 
 		$cart_item = $cart->get_cart_item( $cart_item_key );
-		$product   = $cart_item['data'];
+		$product   = $cart_item['data'] ?? null;
 		if ( empty( $product ) ) {
-			// The item removed from cart no longer exists as a product. Skip sending this event to Sift.
+			// The item removed from cart no longer exists as a product or has missing product data. Skip sending this event to Sift.
 			return;
 		}
 		$user      = wp_get_current_user();

--- a/src/inc/sift-events/sift-events.php
+++ b/src/inc/sift-events/sift-events.php
@@ -499,6 +499,10 @@ class Events {
 
 		$cart_item = $cart->get_cart_item( $cart_item_key );
 		$product   = $cart_item['data'];
+		if ( empty( $product ) ) {
+			// The item removed from cart no longer exists as a product. Skip sending this event to Sift.
+			return;
+		}
 		$user      = wp_get_current_user();
 
 		$properties = array(

--- a/src/inc/sift-events/sift-events.php
+++ b/src/inc/sift-events/sift-events.php
@@ -492,6 +492,7 @@ class Events {
 	 * @return void
 	 */
 	public static function remove_item_from_cart( string $cart_item_key, \WC_Cart $cart ) {
+
 		if ( ! Sift_Event_Types::can_event_be_sent( Sift_Event_Types::$remove_item_from_cart ) ) {
 			return;
 		}
@@ -502,7 +503,7 @@ class Events {
 			// The item removed from cart no longer exists as a product or has missing product data. Skip sending this event to Sift.
 			return;
 		}
-		$user      = wp_get_current_user();
+		$user = wp_get_current_user();
 
 		$properties = array(
 			'$user_id'      => self::format_user_id( $user->ID ?? 0 ),

--- a/tests/RemoveItemFromCartEventTest.php
+++ b/tests/RemoveItemFromCartEventTest.php
@@ -41,6 +41,37 @@ class RemoveItemFromCartEventTest extends EventTest {
 	}
 
 	/**
+	 * Test that the $remove_item_from_cart event is triggered for a product that has already been removed.
+	 *
+	 * @return void
+	 */
+	public function test_remove_item_from_cart_with_removed_product_data() {
+		// Arrange
+		$cart_item_key      = '';
+		$grab_cart_key_func = function ( $_cart_item_key ) use ( &$cart_item_key ) {
+			$cart_item_key = $_cart_item_key;
+		};
+		add_action( 'woocommerce_add_to_cart', $grab_cart_key_func, 10, 1 );
+
+		// Act
+		\WC()->cart->add_to_cart( static::$product_id );
+		$sku = wc_get_product( static::$product_id )->get_sku();
+		\WC()->cart->cart_contents[ $cart_item_key ]['data'] = null;
+		\WC()->cart->remove_cart_item( $cart_item_key );
+
+		// Assert
+		$events  = static::filter_events(
+			[
+				'event'                 => '$remove_item_from_cart',
+				'properties.$item.$sku' => $sku,
+			]
+		);
+		static::assertEquals( 0, count( $events ), 'No $remove_item_from_cart event should be found for removed product.' );
+		// Clean up
+		remove_action( 'woocommerce_add_to_cart', $grab_cart_key_func );
+	}
+
+	/**
 	 * Assert $add_item_to_cart event is triggered.
 	 *
 	 * @param integer $product_id Product ID.

--- a/tests/RemoveItemFromCartEventTest.php
+++ b/tests/RemoveItemFromCartEventTest.php
@@ -60,7 +60,7 @@ class RemoveItemFromCartEventTest extends EventTest {
 		\WC()->cart->remove_cart_item( $cart_item_key );
 
 		// Assert
-		$events  = static::filter_events(
+		$events = static::filter_events(
 			[
 				'event'                 => '$remove_item_from_cart',
 				'properties.$item.$sku' => $sku,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Skip sending the `$remove_item_from_cart` event to Sift in cases where the product being removed no longer exists.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Automated test is included. This bug showed up in production, although it's not entirely clear how to replicate it without automated testing.

Mentions # 628-gh-automattic/gold
