### PR TITLE
Check for existance of classes instead of searching through available…

### DIFF
--- a/src/inc/payment-gateways/load.php
+++ b/src/inc/payment-gateways/load.php
@@ -3,26 +3,22 @@
 add_action(
 	'woocommerce_init',
 	function () {
-		$gateways    = \WC()->payment_gateways->get_available_payment_gateways();
-		$gateway_ids = array_keys( $gateways );
+		if ( class_exists( 'WC_Gateway_Stripe' ) ) {
+			require_once __DIR__ . '/lib/stripe.php';
+			require_once __DIR__ . '/stripe.php';
+		}
 
-		foreach ( $gateway_ids as $gateway_id ) {
-			switch ( $gateway_id ) {
-				case 'stripe':
-					require_once __DIR__ . '/lib/stripe.php';
-					require_once __DIR__ . '/stripe.php';
-					break;
-				case 'ppcp-gateway':
-					require_once __DIR__ . '/ppcp-gateway.php';
-					break;
-				case 'woopayments':
-					require_once __DIR__ . '/transact.php';
-					break;
-				case 'woocommerce_payments':
-					require_once __DIR__ . '/lib/stripe.php';
-					require_once __DIR__ . '/woocommerce-payments.php';
-					break;
-			}
+		if ( class_exists( 'WooCommerce\PayPalCommerce\PPCP' ) ) {
+			require_once __DIR__ . '/ppcp-gateway.php';
+		}
+
+		if ( defined( 'TRANSACT_GATEWAY_PLUGIN_DIR' ) ) {
+			require_once __DIR__ . '/transact.php';
+		}
+
+		if ( class_exists( 'WC_Payments_Features' ) ) {
+			require_once __DIR__ . '/lib/stripe.php';
+			require_once __DIR__ . '/woocommerce-payments.php';
 		}
 	}
 );

--- a/src/inc/payment-gateways/load.php
+++ b/src/inc/payment-gateways/load.php
@@ -20,5 +20,6 @@ add_action(
 			require_once __DIR__ . '/lib/stripe.php';
 			require_once __DIR__ . '/woocommerce-payments.php';
 		}
-	}
+	},
+	1000
 );


### PR DESCRIPTION
… payment gateways

#### Changes proposed in this Pull Request

* When loading payment gateway files, check for the existence of plugin-related classes instead of enumerating through the available payment gateways

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch locally
* `npm start`
* Confirm the files included correctly load for the available payment gateways

Mentions # 630-gh-automattic/gold
