### PR TITLE
Allow pre_send_event_properties to block sending event to Sift

### DIFF
--- a/src/inc/sift-events/sift-events.php
+++ b/src/inc/sift-events/sift-events.php
@@ -875,13 +875,15 @@ class Events {
 		// Give a chance for the platform to modify the data (and add potentially new custom data)
 		$properties = apply_filters( 'sift_for_woocommerce_pre_send_event_properties', $properties, $event );
 
-		array_push(
-			self::$to_send,
-			array(
-				'event'      => $event,
-				'properties' => array_filter( $properties ),
-			)
-		);
+		if ( ! empty( $properties ) ) {
+			array_push(
+				self::$to_send,
+				array(
+					'event'      => $event,
+					'properties' => array_filter( $properties ),
+				)
+			);
+		}
 	}
 
 	/**

--- a/src/inc/sift-events/sift-events.php
+++ b/src/inc/sift-events/sift-events.php
@@ -875,15 +875,17 @@ class Events {
 		// Give a chance for the platform to modify the data (and add potentially new custom data)
 		$properties = apply_filters( 'sift_for_woocommerce_pre_send_event_properties', $properties, $event );
 
-		if ( ! empty( $properties ) ) {
-			array_push(
-				self::$to_send,
-				array(
-					'event'      => $event,
-					'properties' => array_filter( $properties ),
-				)
-			);
+		if ( empty( $properties ) ) {
+			return;
 		}
+
+		array_push(
+			self::$to_send,
+			array(
+				'event'      => $event,
+				'properties' => array_filter( $properties ),
+			)
+		);
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Allow the `sift_for_woocommerce_pre_send_event_properties` filter the ability to prevent adding an event to Sift if the properties are empty.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this patch
* Add a filter for `sift_for_woocommerce_pre_send_event_properties` which returns an empty array under some condition.
* Confirm this event was not sent to Sift.

Mentions 629-gh-automattic/gold
