### PR TITLE
Remove the async queue logic to send Sift events

### DIFF
--- a/src/inc/sift-events/sift-events.php
+++ b/src/inc/sift-events/sift-events.php
@@ -949,12 +949,11 @@ class Events {
 	/**
 	 * Send off events to Sift. This is run async thanks to Action Scheduler.
 	 *
-	 * @param string $event      Event type to send
-	 * @param array  $properties Properties of the Sift event
+	 * @param string $event      Event type to send.
+	 * @param array  $properties Properties of the Sift event.
 	 *
-	 * @return bool
+	 * @return boolean
 	 */
-
 	public static function send_event( string $event, array $properties ): bool {
 
 		$entry = array(

--- a/src/inc/sift-events/sift-events.php
+++ b/src/inc/sift-events/sift-events.php
@@ -24,8 +24,6 @@ use WC_Product;
  * Class Events
  */
 class Events {
-	public static $to_send = array();
-
 	const SUPPORTED_WOO_ORDER_STATUS_CHANGES = array(
 		'pending',
 		'processing',
@@ -939,6 +937,14 @@ class Events {
 		// Give a chance for the platform to modify the data (and add potentially new custom data)
 		$properties = apply_filters( 'sift_for_woocommerce_pre_send_event_properties', $properties, $event );
 
+		// Removed unused properties before queueing and storing the event
+		$properties = array_filter(
+			$properties,
+			function ( $value ) {
+				return null !== $value && '' !== $value;
+			}
+		);
+
 		if ( empty( $properties ) ) {
 			return;
 		}
@@ -966,25 +972,15 @@ class Events {
 			),
 		);
 
-		// Log all events that are about to be sent
-		if ( function_exists( 'wc_get_logger' ) ) {
-			$event_types = array_map(
-				function ( $entry ) {
-					return $entry['event'];
-				},
-				self::$to_send
-			);
-		}
-
 		$client = Sift_For_WooCommerce::get_api_client();
 		if ( empty( $client ) ) {
 			Sift_For_WooCommerce::log(
-				'Failed to send events to Sift',
+				'Failed to send event to Sift',
 				'error',
 				array(
 					'source' => 'sift-for-woocommerce',
 					'reason' => 'Failed to get the Sift API client.',
-					'events' => self::$to_send,
+					'event' => $entry,
 				)
 			);
 			return false;

--- a/src/inc/sift-events/sift-events.php
+++ b/src/inc/sift-events/sift-events.php
@@ -980,7 +980,7 @@ class Events {
 				array(
 					'source' => 'sift-for-woocommerce',
 					'reason' => 'Failed to get the Sift API client.',
-					'event' => $entry,
+					'event'  => $entry,
 				)
 			);
 			return false;

--- a/src/inc/sift-events/sift-events.php
+++ b/src/inc/sift-events/sift-events.php
@@ -53,6 +53,7 @@ class Events {
 		add_action( 'woocommerce_new_order', array( static::class, 'create_order' ), 100, 2 );
 		add_action( 'woocommerce_update_order', array( static::class, 'update_or_create_order' ), 100, 2 );
 		add_action( 'woocommerce_applied_coupon', array( static::class, 'add_promotion' ), 100, 2 );
+		add_action( 'async_sift_for_woocommerce_send_event', array( static::class, 'send_event' ), 10, 2 );
 
 		/**
 		 * We need to break this out into separate actions so we have the $status_transition available.
@@ -71,9 +72,6 @@ class Events {
 		 * https://github.com/woocommerce/woocommerce/pull/45146
 		 */
 		add_action( 'woocommerce_guest_session_to_user_id', array( static::class, 'link_session_to_user' ), 10, 2 );
-
-		// On shutdown, send any queued events.
-		add_action( 'shutdown', array( static::class, 'send' ) );
 	}
 
 	/**
@@ -90,7 +88,7 @@ class Events {
 			return;
 		}
 
-		self::add(
+		self::queue_sending_event(
 			'$logout',
 			array(
 				'$user_id' => self::format_user_id( intval( $user_id ) ),
@@ -138,7 +136,7 @@ class Events {
 			return;
 		}
 
-		self::add( Sift_Event_Types::$add_promotion, $properties );
+		self::queue_sending_event( Sift_Event_Types::$add_promotion, $properties );
 	}
 
 	/**
@@ -180,7 +178,7 @@ class Events {
 			return;
 		}
 
-		self::add( Sift_Event_Types::$login, $properties );
+		self::queue_sending_event( Sift_Event_Types::$login, $properties );
 	}
 
 	/**
@@ -241,7 +239,7 @@ class Events {
 			$properties['$failure_reason'] = $failure_reason;
 		}
 
-		self::add( Sift_Event_Types::$login, $properties );
+		self::queue_sending_event( Sift_Event_Types::$login, $properties );
 	}
 
 	/**
@@ -286,7 +284,7 @@ class Events {
 			return;
 		}
 
-		self::add(
+		self::queue_sending_event(
 			Sift_Event_Types::$create_account,
 			$properties
 		);
@@ -344,7 +342,7 @@ class Events {
 			return;
 		}
 
-		self::add( Sift_Event_Types::$update_account, $properties );
+		self::queue_sending_event( Sift_Event_Types::$update_account, $properties );
 	}
 
 	/**
@@ -386,7 +384,7 @@ class Events {
 			return;
 		}
 
-		self::add( Sift_Event_Types::$update_password, $properties );
+		self::queue_sending_event( Sift_Event_Types::$update_password, $properties );
 	}
 
 	/**
@@ -419,7 +417,7 @@ class Events {
 			return;
 		}
 
-		self::add( Sift_Event_Types::$link_session_to_user, $properties );
+		self::queue_sending_event( Sift_Event_Types::$link_session_to_user, $properties );
 	}
 
 	/**
@@ -475,7 +473,7 @@ class Events {
 			return;
 		}
 
-		self::add(
+		self::queue_sending_event(
 			Sift_Event_Types::$add_item_to_cart,
 			$properties
 		);
@@ -526,7 +524,7 @@ class Events {
 			'$time'         => intval( 1000 * microtime( true ) ),
 		);
 
-		self::add( Sift_Event_Types::$remove_item_from_cart, $properties );
+		self::queue_sending_event( Sift_Event_Types::$remove_item_from_cart, $properties );
 	}
 
 	/**
@@ -664,7 +662,7 @@ class Events {
 		}
 
 		// Add event to queue.
-		self::add( $event, $properties );
+		self::queue_sending_event( $event, $properties );
 	}
 
 	/**
@@ -716,7 +714,7 @@ class Events {
 			return;
 		}
 
-		self::add( Sift_Event_Types::$transaction, $properties );
+		self::queue_sending_event( Sift_Event_Types::$transaction, $properties );
 	}
 
 	/**
@@ -804,7 +802,7 @@ class Events {
 			return;
 		}
 
-		self::add( Sift_Event_Types::$order_status, $properties );
+		self::queue_sending_event( Sift_Event_Types::$order_status, $properties );
 	}
 
 	/**
@@ -839,7 +837,7 @@ class Events {
 			return;
 		}
 
-		self::add( Sift_Event_Types::$chargeback, $properties );
+		self::queue_sending_event( Sift_Event_Types::$chargeback, $properties );
 	}
 
 	/**
@@ -929,22 +927,26 @@ class Events {
 	}
 
 	/**
-	 * Add a Sift Event to the queue.
+	 * Add a Sift Event to the async queue.
 	 *
 	 * @param string $event      The event to enqueue.
 	 * @param array  $properties The properties to send with the event.
 	 *
 	 * @return void
 	 */
-	public static function add( string $event, array $properties ): void {
+	public static function queue_sending_event( string $event, array $properties ): void {
+		as_enqueue_async_action( 'async_sift_for_woocommerce_send_event', [ $event, $properties ] );
+	}
+
+	public static function send_event( string $event, array $properties ): bool {
 		// Give a chance for the platform to modify the data (and add potentially new custom data)
 		$properties = apply_filters( 'sift_for_woocommerce_pre_send_event_properties', $properties, $event );
 
 		if ( empty( $properties ) ) {
-			return;
+			return false;
 		}
 
-		self::$to_send[] = array(
+		$entry = array(
 			'event'      => $event,
 			'properties' => array_filter(
 				$properties,
@@ -953,83 +955,59 @@ class Events {
 				}
 			),
 		);
-	}
 
-	/**
-	 * Return how many events have been registered thus far and are queued up to send.
-	 *
-	 * @return integer
-	 */
-	private static function count(): int {
-		return count( self::$to_send );
-	}
-
-	/**
-	 * Send off the events, if any.
-	 *
-	 * @return boolean
-	 */
-	public static function send(): bool {
-		if ( self::count() > 0 ) {
-			// Log all events that are about to be sent
-			if ( function_exists( 'wc_get_logger' ) ) {
-				$event_types = array_map(
-					function ( $entry ) {
-						return $entry['event'];
-					},
-					self::$to_send
-				);
-			}
-
-			$client = Sift_For_WooCommerce::get_api_client();
-			if ( empty( $client ) ) {
-				Sift_For_WooCommerce::log(
-					'Failed to send events to Sift',
-					'error',
-					array(
-						'source' => 'sift-for-woocommerce',
-						'reason' => 'Failed to get the Sift API client.',
-						'events' => self::$to_send,
-					)
-				);
-				return false;
-			}
-
-			foreach ( self::$to_send as $entry ) {
-				// We need the original user ID to handle the decision locally after events are sent.
-				$user_id = $entry['properties']['$user_id'] ?? null;
-
-				$response = $client->track( $entry['event'], $entry['properties'] );
-
-				if ( 200 !== $response->httpStatusCode ) {
-					Sift_For_WooCommerce::log(
-						sprintf( 'Sent `%s`, Error %d: %s', $entry['event'], $response->apiStatus, $response->apiErrorMessage ),
-						'error',
-						array(
-							'source'     => 'sift-for-woocommerce',
-							'properties' => $entry['properties'],
-							'response'   => $response,
-						)
-					);
-				}
-			}
-
-			// Now that it's sent, clear the $to_send static in case it was run manually.
-			self::$to_send = array();
-
-			// Get the user ID we sent to Sift from the properties.
-			$sift_user_id = $entry['properties']['$user_id'] ?? null;
-
-			// Get the current decision since events have been sent and could have changed the decision.
-			// This is only done if the user ID is set.
-			if ( $sift_user_id ) {
-				// Get the decision for the user and apply if needed.
-				self::get_decision( $sift_user_id, $sift_user_id );
-			}
-
-			return true;
+		// Log all events that are about to be sent
+		if ( function_exists( 'wc_get_logger' ) ) {
+			$event_types = array_map(
+				function ( $entry ) {
+					return $entry['event'];
+				},
+				self::$to_send
+			);
 		}
-		return false;
+
+		$client = Sift_For_WooCommerce::get_api_client();
+		if ( empty( $client ) ) {
+			Sift_For_WooCommerce::log(
+				'Failed to send events to Sift',
+				'error',
+				array(
+					'source' => 'sift-for-woocommerce',
+					'reason' => 'Failed to get the Sift API client.',
+					'events' => self::$to_send,
+				)
+			);
+			return false;
+		}
+
+		// We need the original user ID to handle the decision locally after events are sent.
+		$user_id = $entry['properties']['$user_id'] ?? null;
+
+		$response = $client->track( $entry['event'], $entry['properties'] );
+
+		if ( 200 !== $response->httpStatusCode ) {
+			Sift_For_WooCommerce::log(
+				sprintf( 'Sent `%s`, Error %d: %s', $entry['event'], $response->apiStatus, $response->apiErrorMessage ),
+				'error',
+				array(
+					'source'     => 'sift-for-woocommerce',
+					'properties' => $entry['properties'],
+					'response'   => $response,
+				)
+			);
+		}
+
+		// Get the user ID we sent to Sift from the properties.
+		$sift_user_id = $entry['properties']['$user_id'] ?? null;
+
+		// Get the current decision since events have been sent and could have changed the decision.
+		// This is only done if the user ID is set.
+		if ( $sift_user_id ) {
+			// Get the decision for the user and apply if needed.
+			self::get_decision( $sift_user_id, $sift_user_id );
+		}
+
+		return true;
 	}
 
 	/**

--- a/src/inc/sift-events/sift-events.php
+++ b/src/inc/sift-events/sift-events.php
@@ -935,16 +935,27 @@ class Events {
 	 * @return void
 	 */
 	public static function queue_sending_event( string $event, array $properties ): void {
-		as_enqueue_async_action( 'async_sift_for_woocommerce_send_event', [ $event, $properties ] );
-	}
 
-	public static function send_event( string $event, array $properties ): bool {
 		// Give a chance for the platform to modify the data (and add potentially new custom data)
 		$properties = apply_filters( 'sift_for_woocommerce_pre_send_event_properties', $properties, $event );
 
 		if ( empty( $properties ) ) {
-			return false;
+			return;
 		}
+
+		as_enqueue_async_action( 'async_sift_for_woocommerce_send_event', array( $event, $properties ) );
+	}
+
+	/**
+	 * Send off events to Sift. This is run async thanks to Action Scheduler.
+	 *
+	 * @param string $event      Event type to send
+	 * @param array  $properties Properties of the Sift event
+	 *
+	 * @return bool
+	 */
+
+	public static function send_event( string $event, array $properties ): bool {
 
 		$entry = array(
 			'event'      => $event,

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -160,7 +160,7 @@ abstract class EventTest extends WP_UnitTestCase {
 			]
 		);
 
-		if ( empty( $filters['event'] ?? null ) ) {
+		if ( empty( $filters['event'] ) ) {
 			return null;
 		}
 

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -153,7 +153,12 @@ abstract class EventTest extends WP_UnitTestCase {
 	 */
 	public static function filter_events_gen( $filters = [] ) {
 		// Get the last 25 events queued in actionscheduler
-		$actions = as_get_scheduled_actions( [ 'hook' => 'async_sift_for_woocommerce_send_event', 'per_page' => 25 ] );
+		$actions = as_get_scheduled_actions(
+			[
+				'hook'     => 'async_sift_for_woocommerce_send_event',
+				'per_page' => 25,
+			]
+		);
 
 		if ( empty( $filters['event'] ?? null ) ) {
 			return null;
@@ -166,7 +171,10 @@ abstract class EventTest extends WP_UnitTestCase {
 			}
 
 			$action_args = $action->get_args();
-			$event = [ 'event' => $action_args[0], 'properties' => $action_args[1] ];
+			$event       = [
+				'event'      => $action_args[0],
+				'properties' => $action_args[1],
+			];
 
 			if ( $event['event'] === $filters['event'] ) {
 				$match = true;

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -152,18 +152,36 @@ abstract class EventTest extends WP_UnitTestCase {
 	 * @return generator
 	 */
 	public static function filter_events_gen( $filters = [] ) {
-		foreach ( Events::$to_send as $event ) {
-			$match = true;
-			// flatten the keys to dot notation (e.g. 'key.subkey.subsubkey' => 'value')
-			$event = self::array_dot( $event );
-			foreach ( $filters as $key => $value ) {
-				if ( ! isset( $event[ $key ] ) || $event[ $key ] !== $value ) {
-					$match = false;
-					break;
-				}
+		// Get the last 25 events queued in actionscheduler
+		$actions = as_get_scheduled_actions( [ 'hook' => 'async_sift_for_woocommerce_send_event', 'per_page' => 25 ] );
+
+		if ( empty( $filters['event'] ?? null ) ) {
+			return null;
+		}
+
+		foreach ( $actions as $action ) {
+			// Skip cancelled jobs
+			if ( $action instanceof ActionScheduler_CanceledAction ) {
+				continue;
 			}
-			if ( $match ) {
-				yield $event;
+
+			$action_args = $action->get_args();
+			$event = [ 'event' => $action_args[0], 'properties' => $action_args[1] ];
+
+			if ( $event['event'] === $filters['event'] ) {
+				$match = true;
+				$event = self::array_dot( $event );
+
+				foreach ( $filters as $key => $value ) {
+					if ( ! isset( $event[ $key ] ) || $event[ $key ] !== $value ) {
+						$match = false;
+						break;
+					}
+				}
+
+				if ( $match ) {
+					yield $event;
+				}
 			}
 		}
 	}
@@ -185,7 +203,7 @@ abstract class EventTest extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public static function reset_events() {
-		Sift_For_WooCommerce\Sift_Events\Events::$to_send = [];
+		as_unschedule_all_actions( 'async_sift_for_woocommerce_send_event' );
 	}
 
 	/**

--- a/tests/GenericEventTest.php
+++ b/tests/GenericEventTest.php
@@ -17,34 +17,40 @@ class GenericEventTest extends \EventTest {
 	 * Assert that an event is properly modified with sift_for_woocommerce_pre_send_event_properties
 	 */
 	public function test_sift_for_woocommerce_pre_send_event_properties() {
+		$event_type = 'test_event_name';
 		add_filter( 'sift_for_woocommerce_pre_send_event_properties', function( $properties, $event_name ) {
 			$properties['$user_id'] = 'prefix_' . $properties['$user_id'];
 			$properties['some']     = 'data';
 			return $properties;
 		}, 10, 2 );
 
-		Events::queue_sending_event( 'test_event_name', array( '$user_id' => '12345' ) );
+		Events::queue_sending_event( $event_type, array( '$user_id' => '12345' ) );
 		static::fail_on_error_logged();
 
 		// We see if the event in the stack was modified
-		$event = Events::$to_send[0];
-		static::assertEquals( $event['event'], 'test_event_name', 'Event name not expected.');
-		static::assertEquals( $event['properties']['$user_id'], 'prefix_12345', 'Event param $user_id not expected.');
-		static::assertEquals( $event['properties']['some'], 'data', 'Custom event parameter was not added');
+		$events = static::filter_events( [ 'event' => $event_type ] );
+		static::assertIsArray( $events, 'Failed to find event: ' . $event_type );
+		static::assertEquals( 1, count( $events ), 'No ' . $event_type . ' event found' );
+		$event = reset( $events );
+		static::assertEquals( $event['event'], $event_type, 'Event name not expected.' );
+		static::assertEquals( $event['properties.$user_id'], 'prefix_12345', 'Event param $user_id not expected.' );
+		static::assertEquals( $event['properties.some'], 'data', 'Custom event parameter was not added' );
 
 		static::reset_events();
 
 		// We check when removing the filter
 		remove_all_filters( 'sift_for_woocommerce_pre_send_event_properties' );
 
-		Events::queue_sending_event( 'test_event_name', array( '$user_id' => '12345' ) );
+		Events::queue_sending_event( $event_type, array( '$user_id' => '12345' ) );
 		static::fail_on_error_logged();
 
 		// We see if the event in the stack was modified
-		$event = Events::$to_send[0];
-		static::assertEquals( $event['event'], 'test_event_name', 'Event name not expected.');
-		static::assertEquals( $event['properties']['$user_id'], '12345', 'Event param $user_id not expected.');
-		static::assertTrue( ! isset( $event['properties']['some'] ), 'Custom event was somehow added');
-
+		$events = static::filter_events( [ 'event' => $event_type ] );
+		static::assertIsArray( $events, 'Failed to find event: ' . $event_type );
+		static::assertEquals( 1, count( $events ), 'No ' . $event_type . ' event found' );
+		$event = reset( $events );
+		static::assertEquals( $event['event'], $event_type, 'Event name not expected.' );
+		static::assertEquals( $event['properties.$user_id'], '12345', 'Event param $user_id not expected.' );
+		static::assertTrue( ! isset( $event['properties.some'] ), 'Custom event was somehow added' );
 	}
 }

--- a/tests/GenericEventTest.php
+++ b/tests/GenericEventTest.php
@@ -23,7 +23,7 @@ class GenericEventTest extends \EventTest {
 			return $properties;
 		}, 10, 2 );
 
-		Events::add( 'test_event_name', array( '$user_id' => '12345' ) );
+		Events::queue_sending_event( 'test_event_name', array( '$user_id' => '12345' ) );
 		static::fail_on_error_logged();
 
 		// We see if the event in the stack was modified
@@ -37,7 +37,7 @@ class GenericEventTest extends \EventTest {
 		// We check when removing the filter
 		remove_all_filters( 'sift_for_woocommerce_pre_send_event_properties' );
 
-		Events::add( 'test_event_name', array( '$user_id' => '12345' ) );
+		Events::queue_sending_event( 'test_event_name', array( '$user_id' => '12345' ) );
 		static::fail_on_error_logged();
 
 		// We see if the event in the stack was modified

--- a/tests/UpdateOrderEventTest.php
+++ b/tests/UpdateOrderEventTest.php
@@ -20,6 +20,7 @@ class UpdateOrderEventTest extends EventTest {
 	 * @return void
 	 */
 	public function test_create_order() {
+		self::reset_events();
 		// Arrange
 		// - create a user and log them in
 		$user_id = $this->factory()->user->create();
@@ -60,6 +61,7 @@ class UpdateOrderEventTest extends EventTest {
 	 * @return void
 	 */
 	public function test_create_order_with_invalid_phone_omits_phone() {
+		self::reset_events();
 		// Arrange
 		// - create a user and log them in
 		$user_id = $this->factory()->user->create();


### PR DESCRIPTION
Resolves: https://linear.app/a8c/issue/FRAUD-91/speed-up-process-entries-on-shutdown

WCCOM PR Related to: https://github.com/Automattic/woocommerce.com/pull/24173


#### Changes proposed in this Pull Request
* Immediately queue sift events as async jobs using actionscheduler instead of looping through an array of all events at the end of a process.
* Update sift decision for the user after each event is sent
* Change tests to check actionscheduler queue instead of an array of events

NOTE:  All events/actions are now sent to sift using an async queue.  We do not have control over when the events are actually sent and when we will process the decisions returned from sift.


#### Testing instructions
Automated:
 * git clone https://github.com/woocommerce/sift-for-woocommerce.git
 * yarn  install 
 * composer install 
 * yarn  start
 * yarn  test --

Manual:
Follow readme here: https://github.com/woocommerce/sift-for-woocommerce/
```
git clone https://github.com/woocommerce/sift-for-woocommerce.git
npm install 
composer install 
npm start
```

1. Setup tunnel to site: PCYsg-GJ2-p2
2. update .wp-env.override.json 
    - Configure jurassic tunnel 
    - Update plugins:
		`"https://downloads.wordpress.org/plugin/woocommerce.9.9.5.zip",`
                `"https://downloads.wordpress.org/plugin/woocommerce-payments.9.6.0.zip",`
3. npm run clean && npm run start
4. Setup WooCommerce in wp-admin - walkthrough is launched automatically
    - For business
    - For someone else
    - No extra plugins - just woo payments
    - Connect WP account
    - …continue setup in wp-admin
    - Customize store
    - Setup taxes - i dont charge tax
    - Launch store
5. Setup payments in wp-admin
    - Accept payments with Woo - complete setup
    - Credit card and woopay
6. Setup the sift for woocommerce plugin in wp-admin 
    - Setup sift account with sandbox credentials from here: https://console.sift.com/developer/api-keys?abuse_type=legacy
    - Enable events you want to test
7. Go to shop site and buy something to trigger events
