### PR TITLE
Add basic .htaccess file for local environment

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,11 @@
+# BEGIN WordPress
+
+RewriteEngine On
+RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+RewriteBase /
+RewriteRule ^index\.php$ - [L]
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule . /index.php [L]
+
+# END WordPress

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -18,5 +18,8 @@
     "WP_PROXY_HOST": "socks://host.docker.internal",
     "WP_PROXY_PORT": "8080",
     "WP_DEBUG_LOG": "/var/www/html/wp-content/debug.log"
+  },
+  "mappings": {
+    ".htaccess": ".htaccess"
   }
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a basic `.htaccess` file to fix custom routes / permalinks in the local `wp-env` environment.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Observe a WP environment missing an `.htaccess` file by SSHing into the running `wordpress` container and running `ls -lah` inside `/var/www/html`.
* Checkout this branch.
* Run `npm stop` followed by `npm start`.
* SSH back into the running `wordpress` container and run `ls -lah` inside `/var/www/html`, you should now see that the `.htaccess` file exists and contains the same information as the `.htaccess` file in the root directory of this repository.

Related to FRAUD-111
