### PR TITLE
Added action call to send zendesk notification

### DIFF
--- a/src/inc/sift-decisions/abuse-decisions.php
+++ b/src/inc/sift-decisions/abuse-decisions.php
@@ -119,7 +119,8 @@ add_filter( 'sift_decision_received', __NAMESPACE__ . '\process_sift_decision_re
  * @return \WP_Error|boolean Returns a WP_Error if the user ID is invalid or if the decision ID is not recognized, otherwise true.
  */
 function process_manual_fraud_decision( string $woocommerce_user_id, string $decision_id, string $description, string $analyst ): \WP_Error|bool {
-	if ( empty( $woocommerce_user_id ) ) {
+	$user = get_user_by( 'id', $woocommerce_user_id );
+	if ( ! $user || is_wp_error( $user ) ) {
 		wc_get_logger()->log(
 			'info',
 			"Bad User ID '{$woocommerce_user_id}'",

--- a/src/inc/sift-decisions/abuse-decisions.php
+++ b/src/inc/sift-decisions/abuse-decisions.php
@@ -37,7 +37,8 @@ function process_sift_decision_received( $return_value, $decision_id, $user_id )
 		return $woocommerce_user_id;
 	}
 
-	$automated_actions_enabled = get_option( 'wc_sift_for_woocommerce_automated_actions_enabled' );
+	// Checkbox options are "yes" or "no" values
+	$automated_actions_enabled = ( 'yes' === get_option( 'wc_sift_for_woocommerce_automated_actions_enabled' ) );
 
 	switch ( $decision_id ) {
 		case 'looks_good_payment_abuse':
@@ -49,6 +50,7 @@ function process_sift_decision_received( $return_value, $decision_id, $user_id )
 		case 'likely_fraud_keep_purchases_payment_abuse':
 			if ( $automated_actions_enabled ) {
 				do_action( 'sift_for_woocommerce_likely_fraud_keep_purchases_payment_abuse', $woocommerce_user_id );
+				do_action( 'sift_for_woocommerce_send_decision_notification', $woocommerce_user_id, 'making purchases' );
 			}
 			break;
 

--- a/src/inc/sift-decisions/sift-decision-rest-api-webhooks.php
+++ b/src/inc/sift-decisions/sift-decision-rest-api-webhooks.php
@@ -97,8 +97,8 @@ function decision_webhook( \WP_REST_Request $request ) {
 		'sift_decision_received',
 		null,
 		$json['decision']['id'],
-		$json['entity']['type'],
 		$json['entity']['id'],
+		$json['entity']['type'],
 		$json['time']
 	);
 


### PR DESCRIPTION
Relates to FRAUD-104

#### Changes proposed in this Pull Request

* Added action call to send zendesk notification for `likely_fraud_keep_purchases_payment_abuse` Sift decision via webhook.
    * Note this will only call the new `sift_for_woocommerce_send_decision_notification` which depends on the sidecar action defined in the WCCOM PR to actually send a Zendesk message:
        * https://github.com/Automattic/woocommerce.com/pull/24309
* Fixed param order for `sift_decision_received` filter - entity type was being passed instead of user_id to `function process_sift_decision_received( $return_value, $decision_id, $user_id )` in abuse_decitions.php, as is already being done in the `apply_filters` call in sift-events.php::apply_decision
* Fixed automated decision option check to make sure the option is enabled correctly.

#### Testing instructions

1. Load the PR and optionally configure your local sift for woo environment to load https://github.com/Automattic/woocommerce.com/pull/24309 for sending a Zendesk notification
 * NOTE: This PR will only call the new `sift_for_woocommerce_send_decision_notification` which depends on the sidecar action defined in the referenced WCCOM PR to actually send a Zendesk message.  You will need to configure your local sift for woo environment to use a woocommerce version that includes that WCCOM PR to send an actual zendesk message.   
 * ALSO NOTE: if you do send a zendesk message, it will appear in the production zendesk queue:
     *  example: 10111136-zd-a8c
 * However, it WILL process the user as likely fraud and block them from making purchases locally even without that PR.

2. Enable Automated actions:
 * Edit Sift for Woo options in: /wp-admin/admin.php?page=wc-settings&tab=sift_for_woocommerce
 * Enable(check) the `Enable Automated Actions` field

3.  Gather some testing data:
{SFW_INSTANCE_URL}
 * The url where you are running Sift For Woo: localhost/ngrok/jurassictube
 * ex: glowing-redfish-hardly.ngrok-free.app

{SIFT_WEBHOOK_KEY}
 * The webhook requires/validates a hash in the request header: `X-Sift-Science-Signature`
 * The hash (if one doesn't already exist) needs to be added to the `Sift Signature / Webhook Key ` Sift for Woo option in: /wp-admin/admin.php?page=wc-settings&tab=sift_for_woocommerce
    * add and/or copy a 40 character hash value:  you can generate a new one to use locally with `openssl rand -hex 20`

{USER_ID}
 * The webhook expects either a WPCOM user id, OR a WCCOM user ID prefixed with the string `wccom_`
     * WCCOM ex `wccom_17` for local WCCOM USER ID 17
     * WPCOM ex. 259025665 for a WPCOM USER ID that is mapped to a wccom user locally via user_meta data:
         * user_meta:wp_woocommerce_wpcom_signin_user_id
         * `$wpcom_user_id = get_user_meta( $wccom_user_id, 'wp_woocommerce_wpcom_signin_user_id', true );`


4. Make a call to the webhook using the values you gathered above in the curl call below to trigger the new `sift_for_woocommerce_send_decision_notification` action:
{SFW_INSTANCE_URL}
{SIFT_WEBHOOK_KEY}
{USER_ID}

```
curl --location --request GET 'https://{SFW_INSTANCE_URL}/wp-json/sift-for-woocommerce/v1/decision' \
--header 'X-Sift-Science-Signature: {SIFT_WEBHOOK_KEY}' \
--header 'Content-Type: application/json' \
--data '{
  "decision": {
      "id": "likely_fraud_keep_purchases_payment_abuse"
  },
  "entity": {
    "id": "{USER_ID}",
    "type":"user"
  },
  "time":"123456"
}'
```





Mentions #