### PR TITLE
Added user_id to order event properties before user mapping takes place.

### DIFF
--- a/src/inc/sift-events/sift-events.php
+++ b/src/inc/sift-events/sift-events.php
@@ -492,7 +492,8 @@ class Events {
 
 		$properties = array(
 			'$session_id' => WC()->session?->get_customer_unique_id() ?? '',
-			'$order_id'   => $order_id,
+			'$order_id'   => (string) $order->get_id(),
+			'$user_id'    => self::format_user_id( $order->get_user_id() ),
 			'$browser'    => self::get_client_browser(),
 			'$ip'         => self::get_client_ip(),
 			'$time'       => intval( 1000 * microtime( true ) ),
@@ -775,10 +776,6 @@ class Events {
 	 * @return void
 	 */
 	public static function queue_sending_event( string $event, array $properties ): void {
-
-		// Give a chance for the platform to modify the data (and add potentially new custom data)
-		$properties = apply_filters( 'sift_for_woocommerce_pre_send_event_properties', $properties, $event );
-
 		// Removed unused properties before queueing and storing the event
 		$properties = self::recursively_remove_empty_properties( $properties );
 
@@ -898,8 +895,24 @@ class Events {
 		// Hydrate full properties from job data if needed
 		$properties = self::hydrate_event_properties( $event, $properties );
 
+		// Give a chance for the platform to modify the data (and add potentially new custom data)
+		$properties = apply_filters( 'sift_for_woocommerce_pre_send_event_properties', $properties, $event );
+
 		// Remove blank properties before sending to Sift API
 		$properties = self::recursively_remove_empty_properties( $properties );
+
+		if ( empty( $properties ) ) {
+			Sift_For_WooCommerce::log(
+				'Failed to send Sift event',
+				'debug',
+				array(
+					'source' => 'sift-for-woocommerce',
+					'reason' => 'Empty properties',
+					'event'  => $event,
+				)
+			);
+			return false;
+		}
 
 		// Validate the full properties before sending to Sift API
 		if ( ! self::validate_event_properties( $event, $properties ) ) {
@@ -1037,18 +1050,12 @@ class Events {
 	/**
 	 * Get the address details in the format that Sift expects.
 	 *
-	 * @param string $order_id The User / Customer ID.
-	 * @param string $type     Either `billing` or `shipping`.
+	 * @param \WC_Order $order The Order object.
+	 * @param string    $type  Either `billing` or `shipping`.
 	 *
 	 * @return array|null
 	 */
-	private static function get_order_address( string $order_id, string $type = 'billing' ): ?array {
-		$order = wc_get_order( $order_id );
-
-		if ( empty( $order ) ) {
-			return null;
-		}
-
+	private static function get_order_address( \WC_Order $order, string $type = 'billing' ): ?array {
 		switch ( strtolower( $type ) ) {
 			// WC_Order doesn't have the same `->get_billing` and `->get_shipping()` that the Customer object
 			// has, so we call this way instead.  It also assumes `view`
@@ -1411,14 +1418,12 @@ class Events {
 		$sift_order = Sift_For_WooCommerce::get_sift_order_from_wc_order( $order );
 
 		// Add full order details to existing properties
-		$properties['$user_id']                   = self::format_user_id( $order->get_user_id() );
-		$properties['$order_id']                  = (string) $order->get_id();
 		$properties['$user_email']                = $order->get_billing_email();
 		$properties['$verification_phone_number'] = str_starts_with( $order->get_billing_phone(), '+' ) ? preg_replace( '/[^0-9+]/', '', $order->get_billing_phone() ) : null;
 		$properties['$amount']                    = self::get_transaction_micros( floatval( $order->get_total() ) );
 		$properties['$currency_code']             = $order->get_currency();
-		$properties['$billing_address']           = self::get_order_address( (string) $order->get_id(), 'billing' );
-		$properties['$shipping_address']          = self::get_order_address( (string) $order->get_id(), 'shipping' );
+		$properties['$billing_address']           = self::get_order_address( $order, 'billing' );
+		$properties['$shipping_address']          = self::get_order_address( $order, 'shipping' );
 		$properties['$expedited_shipping']        = false;
 		$properties['$items']                     = array();
 

--- a/tests/EventHydrationTest.php
+++ b/tests/EventHydrationTest.php
@@ -137,6 +137,7 @@ class EventHydrationTest extends EventTest {
 		$properties = array(
 			'$session_id' => 'test_session_123',
 			'$order_id'   => (string) $order->get_id(),
+			'$user_id'    => $user_id,
 			'$browser'    => array( '$user_agent' => 'Test Agent' ),
 			'$ip'         => '192.168.1.1',
 			'$time'       => 1234567890000,

--- a/tests/GenericEventTest.php
+++ b/tests/GenericEventTest.php
@@ -24,7 +24,8 @@ class GenericEventTest extends \EventTest {
 			return $properties;
 		}, 10, 2 );
 
-		Events::queue_sending_event( $event_type, array( '$user_id' => '12345' ) );
+		$properties = array( '$user_id' => '12345' );
+		Events::queue_sending_event( $event_type, $properties);
 		static::fail_on_error_logged();
 
 		// We see if the event in the stack was modified
@@ -33,10 +34,12 @@ class GenericEventTest extends \EventTest {
 		static::assertEquals( 1, count( $events ), 'No ' . $event_type . ' event found' );
 		$event = reset( $events );
 		static::assertEquals( $event['event'], $event_type, 'Event name not expected.' );
-		static::assertEquals( $event['properties.$user_id'], 'prefix_12345', 'Event param $user_id not expected.' );
-		static::assertEquals( $event['properties.some'], 'data', 'Custom event parameter was not added' );
-
 		static::reset_events();
+
+		$properties = Events::hydrate_event_properties( $event['event'], $properties );
+		$properties = apply_filters( 'sift_for_woocommerce_pre_send_event_properties', $properties, $event['event'] );
+		static::assertEquals( $properties['$user_id'], 'prefix_12345', 'Event param $user_id not expected.' );
+		static::assertEquals( $properties['some'], 'data', 'Custom event parameter was not added' );
 
 		// We check when removing the filter
 		remove_all_filters( 'sift_for_woocommerce_pre_send_event_properties' );


### PR DESCRIPTION
Related to: FRAUD-113
WCCOM PR: https://github.com/Automattic/woocommerce.com/pull/24485


#### Changes proposed in this Pull Request

* Lookup WCCOM User ID from the order and add it to the Sift event properties for orders before we queue the async job 
* Move the call to the sidecar plugin filter sift_for_woocommerce_pre_send_event_properties ( which modifies user ID and order ID properties) to send_event - after the data is hydrated.
* Remove the user_id and order_id properties from `hydrate_order_properties` since they are already set in `update_or_create_order`
* Pass the order object to the address lookup function instead of looking it up by order ID again


#### Reson for Change
Create and update order events are sending the wrong data to Sift and the sift decision webhook callback we receive from Sift has the wrong/missing user.
 * We should send Sift the WPCOM User ID in the payload, but we are currently sending the WCCOM User ID.  
 * When we run the scheduled job and try to send a create/update order event, we can't lookup the existing event with `wc_get_order` because the order ID has been changed so we don't find the order details to hydrate.
     * We run a filter sift_for_woocommerce_pre_send_event_properties which alters event properties by calling `translate_user_id_to_wpcom_user_id` & `send_order_id_not_post_id`.
        * `translate_user_id_to_wpcom_user_id` maps the WCCOM User ID to WPCOM User ID which we need to send to Sift
        * `send_order_id_not_post_id` changes the Order ID to the `_order_number` meta value for the order
    
Create and update account events are affected as well.  The user ID is changed from WCCOM to WPCOM before we hydrate user data.
 

### Affected flows
 * Ordering / Cart / Checkout
 * Account

#### Testing instructions

See pfOicC-FM-p2 for local environment setup.

1. Check out this branch on your local environment.
2. Add an item to cart and checkout
3. Look at logs (debug.log) to see if the order event has an error mapping the user: `User ID is not set or empty.`
```  
  [16-Sep-2025 22:04:04 UTC] WCCOM\Logstash: { 
      "site_id": 1,
      "blog_id": 1,    
      "http_host": "glowing-redfish-hardly.ngrok-free.app",
      "severity": "error",
      "feature": "a8c_vip_sift-for-woocommerce",                                                                                                                               
      "message": "User ID is not set or empty.",
      "user_id": 17,
      "extra": "{\n    \"properties\": {\n        \"$session_id\": \"17\",\n        \"$order_id\": \"3578273\",\n        \"$browser\": {\n            \"$user_agent\": \"mozill  a-5-0-macintosh-intel-mac-os-x-10_15_7-applewebkit-537-36-khtml-like-gecko-chrome-140-0-0-0-safari-537-36\",\n            \"$accept_language\": \"en-usenq09\",\n              \"$content_language\": \"en_US\"\n        },\n        \"$ip\": \"192.69.186.249\",\n        \"$time\": 1758060243148\n    },\n    \"locale\": \"en_US\"\n}",
      "timestamp": "2025-09-16 22:04:03",
      "index": "log2logstash",
      "http_user_agent": "Mozilla\/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/140.0.0.0 Safari\/537.36",
      "file": "\/var\/www\/html\/wp-content\/plugins\/wccom-plugins\/logger\/includes\/class-logger.php",
      "line": "103"
  }
  [1
```
4. go to scheduled actions in [wp-admin](https://glowing-redfish-hardly.ngrok-free.app/wp-admin/tools.php?page=action-scheduler&status=pending&orderby=schedule&order=desc&s=sift&action=-1&paged=1&action2=-1) and search the event you just triggered: search for  the pending scheduled event 
    - check the Arguments have the correct user ID and order ID
    - run the job (if it hasn't already run).   
5. update your shipping address and follow the same steps as above to check the Scheduled actions and logs