### PR TITLE
Fixed decision processing, user ID mapping, and zendesk notification ordering

### DIFF
--- a/src/inc/sift-decisions/abuse-decisions.php
+++ b/src/inc/sift-decisions/abuse-decisions.php
@@ -50,8 +50,8 @@ function process_sift_decision_received( $return_value, $decision_id, $user_id )
 		case 'likely_fraud_block_keep_purch_payment_abuse':
 		case 'likely_fraud_keep_purchases_payment_abuse':
 			if ( $automated_actions_enabled ) {
-				do_action( 'sift_for_woocommerce_likely_fraud_keep_purchases_payment_abuse', $woocommerce_user_id );
 				do_action( 'sift_for_woocommerce_send_decision_notification', $woocommerce_user_id, 'making purchases' );
+				do_action( 'sift_for_woocommerce_likely_fraud_keep_purchases_payment_abuse', $woocommerce_user_id );
 			}
 			break;
 
@@ -153,6 +153,9 @@ function process_manual_fraud_decision( string $woocommerce_user_id, string $dec
 			break;
 
 		case 'likely_fraud_keep_purchases_payment_abuse':
+		case 'likely_fraud_block_keep_purch_payment_abuse':
+			// Normalize descision_id
+			$decision_id = 'likely_fraud_block_keep_purch_payment_abuse';
 			do_action( 'sift_for_woocommerce_likely_fraud_keep_purchases_payment_abuse', $woocommerce_user_id );
 			break;
 
@@ -275,8 +278,11 @@ function send_decision_to_sift(
 		$options['description'] = $description;
 	}
 
+	// Translate the user ID to send to Sift if needed.
+	$sift_user_id = apply_filters( 'sift_for_woocommerce_translate_user_id_for_decision', $woocommerce_user_id );
+
 	$response = $client->applyDecisionToUser(
-		$woocommerce_user_id,
+		$sift_user_id,
 		$decision_id,
 		'MANUAL_REVIEW',
 		$options

--- a/src/sift-for-woocommerce.php
+++ b/src/sift-for-woocommerce.php
@@ -179,4 +179,19 @@ class Sift_For_WooCommerce {
 
 		wc_get_logger()->log( $level, $message, $context );
 	}
+
+	/**
+	 * Check if a user has a new purchase block.
+	 *
+	 * This provides a public API for other plugins to check if a user
+	 * has been flagged for fraud. The actual implementation is provided
+	 * via the filter hook.
+	 *
+	 * @param integer $user_id The user ID to check.
+	 *
+	 * @return boolean Returns true if blocked, false otherwise.
+	 */
+	public static function has_new_purchase_block( $user_id ): bool {
+		return apply_filters( 'sift_for_woocommerce_has_new_purchase_block', $user_id, false );
+	}
 }


### PR DESCRIPTION
Related to #FRAUD-118
Related to https://github.com/Automattic/woocommerce.com/pull/24635

###  Description

  This PR improves fraud decision handling in Sift for WooCommerce by fixing decision processing, user ID mapping, and notification ordering.

###  Changes in this PR

Fraud Decision Processing
  - Normalized manual decision handling: When processing the manual decision likely_fraud_keep_purchases_payment_abuse, the code now correctly normalizes it to
  likely_fraud_block_keep_purch_payment_abuse before sending to Sift (abuse-decisions.php:155-158). This ensures Sift logs the correct decision ID in their system.
  - Added decision case handling: The manual decision processor now handles both likely_fraud_keep_purchases_payment_abuse and likely_fraud_block_keep_purch_payment_abuse decision
  IDs (abuse-decisions.php:155-156).

User ID Translation
  - Fixed user ID mapping for Sift decisions: Added user ID translation using the sift_for_woocommerce_translate_user_id_for_decision filter before sending manual decisions to Sift (abuse-decisions.php:281-284). This ensures the correct WordPress user ID is sent to Sift instead of the WC.com user ID.

Notification Ordering
  - Reordered Zendesk notification: Moved the sift_for_woocommerce_send_decision_notification action to fire BEFORE the sift_for_woocommerce_likely_fraud_keep_purchases_payment_abuse action (abuse-decisions.php:53-54). This ensures the Zendesk ticket is created before the user block is applied, preventing duplicate notifications for users who are already blocked.

Public API
  - Added has_new_purchase_block() helper method: Exposed a public static method Sift_For_WooCommerce::has_new_purchase_block($user_id) that can be easily used by other plugins (like the sidecar or WooCommerce.com) to determine a user's fraud flag status without directly accessing user meta (sift-for-woocommerce.php:184-197). 

  Why These Changes Were Needed
  1. Prevent duplicate Zendesk notifications: By moving the notification before the block action, we ensure that the notification check for existing blocks happens before we set the block flag, preventing duplicate tickets from being sent when a user is already blocked.
  2. Fix Sift decision logging: Sift was not receiving the correct decision ID (likely_fraud_block_keep_purch_payment_abuse) when processing likely_fraud_keep_purchases_payment_abuse manual decisions. This normalization ensures Sift's system correctly logs the manual decision.
  3. Correct user identification: Manual decisions were being sent to Sift with WC.com user IDs instead of WordPress user IDs, causing mismatches in Sift's system. The translation filter ensures the correct user ID format is used.
  4. Enable external fraud status checks: The new public helper method provides a clean API for other systems to check fraud status without tight coupling to internal implementation  details (user meta keys).

#### Testing instructions
npm start 
npm test --

Full manual test instructions are in https://github.com/Automattic/woocommerce.com/pull/24635

Mentions #
