### PR TITLE
Fix manual fraud decision handler to accept correct decision ID

### DIFF
--- a/src/inc/sift-decisions/abuse-decisions.php
+++ b/src/inc/sift-decisions/abuse-decisions.php
@@ -63,7 +63,7 @@ function process_sift_decision_received( $return_value, $decision_id, $user_id )
 
 		case 'trust_list_payment_abuse':
 		case 'not_likely_fraud_payment_abuse':
-		case 'likely_fraud_refundno_renew_payment_abuse':
+		case 'likely_fraud_no_purchases_payment_abuse_1':
 		case 'fraud_payment_abuse':
 		case 'fraud_no_review_ticket_payment_abuse':
 		case 'looks_ok_payment_abuse':
@@ -148,7 +148,7 @@ function process_manual_fraud_decision( string $woocommerce_user_id, string $dec
 			do_action( 'sift_for_woocommerce_not_likely_fraud_payment_abuse', $woocommerce_user_id );
 			break;
 
-		case 'likely_fraud_refundno_renew_payment_abuse':
+		case 'likely_fraud_no_purchases_payment_abuse_1':
 			do_action( 'sift_for_woocommerce_likely_fraud_refundno_renew_payment_abuse', $woocommerce_user_id );
 			break;
 

--- a/tests/UpdatePasswordEventTest.php
+++ b/tests/UpdatePasswordEventTest.php
@@ -85,6 +85,9 @@ class DisbaledEventTest extends EventTest {
 		$user_id = $this->factory()->user->create();
 		$user    = get_user_by( 'ID', $user_id );
 
+		// - reset events from user creation (wp_set_password is called during user creation)
+		self::reset_events();
+
 		// Act
 		// - update the user
 		$password = wp_generate_password();


### PR DESCRIPTION
part of #FRAUD-131                                                                                                                                                          
                                                                     
Related to https://github.com/Automattic/woocommerce.com/pull/24800
                                                                                                         
## Proposed changes                                                                                                                                                         
                                                                                                                                                                              
  * Update `process_sift_decision_received()` case from `likely_fraud_refundno_renew_payment_abuse` to `likely_fraud_no_purchases_payment_abuse_1`                            
  * Update `process_manual_fraud_decision()` case from `likely_fraud_refundno_renew_payment_abuse` to `likely_fraud_no_purchases_payment_abuse_1`                             
                                                                                                                                                                              
## Why are these changes being made?                                                                                                                                        
                                                                                                                                                                              
  "Likely fraud (refund/no renew)" from WPCOM Manual Fraud Decisions was not handled. The handler expected `likely_fraud_refundno_renew_payment_abuse` but WPCOM sends the shared Sift decision ID `likely_fraud_no_purchases_payment_abuse_1`.                                               
                                                                                                                                                                                                                                                                                                                                                        
## Testing instructions                                                                                                                                                     
    
1. Follow the readme [here](https://github.com/woocommerce/sift-for-woocommerce/blob/trunk/README.md) to setup a Local Environment.
2. Open [sift console](https://console.sift.com/developer/api-keys?abuse_type=payment_abuse) and **make sure you are in Sandbox Mode** - you will need the Sandbox Account ID and an API Key for the next step
3. Go to wp-admin/admin.php?page=wc-settings&tab=sift_for_woocommerce
     - Fill out the Sandbox Account ID and an API Key from the sift console above
     - Fill out Sift Signature / Webhook Key: if empty, add a 40 character hash value:  you can generate a new one to use locally with `openssl rand -hex 20`
    - Enable Automated Actions: Enable(check) the field -NOTE: this will enable all enable ALL automated decisions 
4.  edit ./.wp-env.json (or copy to .wp-env.override.json) and add an API Secret for authorizing API requests
    - bin2hex(random_bytes(48))
    - add the result of bin2hex to .wp-env.override.json inside config:
        - `"config": { "SIFT_FOR_WOOCOMMERCE_API_SECRET": "the long hash goes here" }`
    - or manually edit /plugins/sift-for-woocommerce/src/inc/rest-api.php locally and override authorization
5. Create a user if needed for manual testing: `wp-env run cli wp user create mytester mytester+123456@example.com --password=password password123` && `wp-env run cli wp user list`
6. Load the PR 
7.  Gather some testing data:
{SFW_INSTANCE_URL}
 * The url where you are running: staging.woocommerce.com/localhost/ngrok/jurassictube
 * ex: foo-bar.ngrok-free.app

{SIFT_WEBHOOK_KEY}
 * The webhook requires/validates a hash in the request header: `X-Sift-Science-Signature`
 * Use the hash from the `Sift Signature / Webhook Key ` Sift for Woo option in: /wp-admin/admin.php?page=wc-settings&tab=sift_for_woocommerce 

{USER_ID}
 * The webhook expects either a WPCOM user id, OR a WCCOM user ID prefixed with the string `wccom_`
     * WCCOM ex `wccom_17` for local WCCOM USER ID 17
     * WPCOM ex. 259025665 for a WPCOM USER ID that is mapped to a wccom user locally via user_meta data:
         * user_meta:wp_woocommerce_wpcom_signin_user_id
         * `$wpcom_user_id = get_user_meta( $wccom_user_id, 'wp_woocommerce_wpcom_signin_user_id', true );`

8.  Check out this branch on your local environment.

### Manual API Testing                                                                                                                                                          

To generate an Authorization header `{AUTH_HEADER}`:
 - `$time=time();`
 - `$endpoint = '/fraud/users/{$woocommerce_user_id}/decision';`		
 - `$hash = hash_hmac( 'sha256', "{$endpoint}|{$time}", $api_secret );`
 - `$auth_header_value = "{$endpoint}|{$time}|{$hash}";`
 - Or just return true from rest-api.php:verify_authorization method


`POST /sift-for-woocommerce/v1/fraud/users/{$woocommerce_user_id}/decision`
 - Three body parameters are expected:
     - `decision_id`: REQUIRED: The decision to be applied to the user - likely_fraud_no_purchases_payment_abuse_1
     - `description` A description of the change which will be logged and sent to sift.
     - `analyst`:  The username of the user making the request, which will be logged and sent to sift.
  - Valid Manual Decisions (see above) should do the following: 
      - run their appropriate actions
          - the actual actions (eg. likely_fraud_no_purchases_payment_abuse_1) only exist in woocommerce.com sidecar plugin.  They will be called but will not run in this environment and make any changes to the user.
      - send the decision to sift
          - and be logged in: https://console.sift.com/developer/api-logs?abuse_type=payment_abuse&type=decision&cache_bust=1753993426029
      - be logged (to error log locally): 'Manual Sift Decision Applied'
          - `wp-env run cli bash`
          - `tail -f /var/www/html/wp-content/debug.log`
      - store the last decision_id in user_meta:sfw_fraud_risk_decision
          - `get_user_meta( $woocommerce_user_id,'sfw_fraud_risk_decision', true )`
          - and should match the result from the new GET endpoint:
              - `GET /sift-for-woocommerce/v1/fraud/users/{$woocommerce_user_id}/decision`

```
curl --location 'https://{SFW_INSTANCE_URL}/wp-json/sift-for-woocommerce/v1/fraud/users/{$woocommerce_user_id}/decision' \
--header 'Authorization: {AUTH_HEADER}' \
--header 'Content-Type: application/json' \
--data '{
    "decision_id":"likely_fraud_no_purchases_payment_abuse_1",
    "description":"Manual Change from CURL",
    "analyst":"tx2pnw"
}'
```

# VIA USER RC
- Update the URL and secret used to connect to your local woocommerce instance (via ngrok/jurassic) on your sandbox:  wpcom/public_html/wp-content/lib/billingdaddy/src/fraud/api-clients/woocommerce-client.php : construct

- Navigate to User RC for a user linked via SSO to WCCOM on your local woocommerce instance
    -  https://dev-mc.a8c.com/tools/reportcard/user/?id=259025665 
- Select `Likely fraud (refund/no renew)`
- Unselect/Deselect `Apply Action on WPCOM`
- Select `Apply Action on WCCOM`
- Click `Apply` decision  

    BEFORE FIX: `Error:WCCOM: Failed to apply fraud decision`
    AFTER FIX: `Success:Fraud decision 'Likely fraud (refund/no renew)' applied successfully to WCCOM.`
                                                                                                                                                                         