### PR TITLE
Remove automated looks_good decision handling

### DIFF
--- a/src/inc/sift-decisions/abuse-decisions.php
+++ b/src/inc/sift-decisions/abuse-decisions.php
@@ -41,12 +41,6 @@ function process_sift_decision_received( $return_value, $decision_id, $user_id )
 	$automated_actions_enabled = ( 'yes' === get_option( 'wc_sift_for_woocommerce_automated_actions_enabled' ) );
 
 	switch ( $decision_id ) {
-		case 'looks_good_payment_abuse':
-			if ( $automated_actions_enabled ) {
-				do_action( 'sift_for_woocommerce_looks_good_payment_abuse', $woocommerce_user_id );
-			}
-			break;
-
 		case 'likely_fraud_block_keep_purch_payment_abuse':
 		case 'likely_fraud_keep_purchases_payment_abuse':
 			if ( $automated_actions_enabled ) {
@@ -61,6 +55,7 @@ function process_sift_decision_received( $return_value, $decision_id, $user_id )
 			}
 			break;
 
+		case 'looks_good_payment_abuse':
 		case 'trust_list_payment_abuse':
 		case 'not_likely_fraud_payment_abuse':
 		case 'likely_fraud_no_purchases_payment_abuse_1':
@@ -141,7 +136,7 @@ function process_manual_fraud_decision( string $woocommerce_user_id, string $dec
 			break;
 
 		case 'looks_good_payment_abuse':
-			do_action( 'sift_for_woocommerce_looks_good_payment_abuse', $woocommerce_user_id );
+			do_action( 'sift_for_woocommerce_looks_good_payment_abuse', $woocommerce_user_id, false );
 			break;
 
 		case 'not_likely_fraud_payment_abuse':


### PR DESCRIPTION
Part of #[FRAUD-127](https://linear.app/a8c/issue/FRAUD-127/sfw-ignore-looks-good-automated-action)                                                                                                                                                      
Related to https://github.com/Automattic/woocommerce.com/pull/24817

### Description

Automated `looks_good` decisions triggered user unblocks, which should only happen with manual analyst review. This change aligns WCCOM behavior with WPCOM, where automated `looks_good` does nothing and only manual `looks_good` removes purchase blocks.

### Changes in this PR

  * Remove `looks_good_payment_abuse` case from automated webhook handler in `abuse-decisions.php`                                                                            
  * Move it to the default case list (logs only, takes no action)        
  
### Test instructions                                                                                                                                                     
                                                                                                                                                                              
  1. Follow the readme https://github.com/woocommerce/sift-for-woocommerce/blob/trunk/README.md to setup a Local Environment.                                                 
  2. Open https://console.sift.com/developer/api-keys?abuse_type=payment_abuse and make sure you are in Sandbox Mode - you will need the Sandbox Account ID and an API Key for the next step
  3. Go to wp-admin/admin.php?page=wc-settings&tab=sift_for_woocommerce                                                                                                       
    - Fill out the Sandbox Account ID and an API Key from the sift console above                                                                                              
    - Fill out Sift Signature / Webhook Key: if empty, add a 40 character hash value: you can generate a new one to use locally with openssl rand -hex 20                     
    - Enable Automated Actions: Enable(check) the field - NOTE: this will enable ALL automated decisions                                                                      
  4. Edit ./.wp-env.json (or copy to .wp-env.override.json) and add an API Secret for authorizing API requests                                                                
    - bin2hex(random_bytes(48))                                                                                                                                               
    - add the result to .wp-env.override.json inside config:                                                                                                                  
        - "config": { "SIFT_FOR_WOOCOMMERCE_API_SECRET": "the long hash goes here" }                                                                                          
    - or manually edit /plugins/sift-for-woocommerce/src/inc/rest-api.php locally and override authorization                                                                  
  5. Create a test user: wp-env run cli wp user create mytester mytester+123456@example.com --password=password123 && wp-env run cli wp user list                             
  6. Load the PR                                                                                                                                                              
  7. Gather testing data:                                                                                                                                                     
                                                                                                                                                                              
  {SFW_INSTANCE_URL}                                                                                                                                                          
  - The url where you are running: localhost/ngrok/jurassictube                                                                                                               
  - ex: foo-bar.ngrok-free.app                                                                                                                                                
                                                                                                                                                                              
  {SIFT_WEBHOOK_KEY}                                                                                                                                                          
  - The webhook requires/validates a hash in the request header: X-Sift-Science-Signature                                                                                     
  - Use the hash from the Sift Signature / Webhook Key option in: /wp-admin/admin.php?page=wc-settings&tab=sift_for_woocommerce                                               
                                                                                                                                                                              
  {USER_ID}                                                                                                                                                                   
  - The webhook expects either a WPCOM user id, OR a WCCOM user ID prefixed with wccom_                                                                                       
    - WCCOM ex: wccom_17 for local WCCOM USER ID 17                                                                                                                           
    - WPCOM ex: 259025665 for a WPCOM USER ID mapped via user_meta wp_woocommerce_wpcom_signin_user_id                                                                        
                                                                                                                                                                              
  ---                                                                                                                                                                         
  Test 1: Automated looks_good webhook does NOT unblock user                                                                                                                  
                                                                                                                                                                              
  1. Block the test user:                                                                                                                                                     
  wp-env run cli wp user meta add {USER_ID} is_blocked_from_purchases true                                                                                                    
                                                                                                                                                                              
  2. Verify blocked:                                                                                                                                                          
  wp-env run cli wp user meta get {USER_ID} is_blocked_from_purchases                                                                                                         
  # Expected: "true"                                                                                                                                                          
                                                                                                                                                                              
  3. Generate webhook signature:                                                                                                                                              
  $body = '{"entity":{"type":"user","id":"{USER_ID}"},"decision":{"id":"looks_good_payment_abuse"},"time":' . time() . '}';                                                   
  $signature = hash_hmac('sha1', $body, '{SIFT_WEBHOOK_KEY}');                                                                                                                
                                                                                                                                                                              
  4. Send automated webhook:                                                                                                                                                  
  curl --location 'https://{SFW_INSTANCE_URL}/wp-json/sift-for-woocommerce/v1/decision/' \                                                                                    
  --header 'X-Sift-Science-Signature: {signature}' \                                                                                                                          
  --header 'Content-Type: application/json' \                                                                                                                                 
  --data '{                                                                                                                                                                   
      "entity": {"type": "user", "id": "{USER_ID}"},                                                                                                                          
      "decision": {"id": "looks_good_payment_abuse"},                                                                                                                         
      "time": 1234567890                                                                                                                                                      
  }'                                                                                                                                                                          
                                                                                                                                                                              
  5. Check logs:                                                                                                                                                              
  wp-env run cli bash                                                                                                                                                         
  tail -f /var/www/html/wp-content/debug.log                                                                                                                                  
  **BEFORE FIX:** No "not handled" log, user unblocked                                                                                                                        
  **AFTER FIX:** Log shows `Decision ID 'looks_good_payment_abuse' not handled.`                                                                                              
  6. Verify user remains blocked:                                                                                                                                             
  wp-env run cli wp user meta get {USER_ID} is_blocked_from_purchases                                                                                                         
  **BEFORE FIX:** "" (meta deleted, user unblocked)                                                                                                                           
  **AFTER FIX:** "true" (user still blocked)                                                                                                                                  
  ---                                                                                                                                                                         
  Test 2: Manual looks_good API call DOES unblock user                                                                                                                        
                                                                                                                                                                              
  To generate Authorization header {AUTH_HEADER}:                                                                                                                             
  $time = time();                                                                                                                                                             
  $endpoint = '/fraud/users/{USER_ID}/decision';                                                                                                                              
  $hash = hash_hmac('sha256', "{$endpoint}|{$time}", $api_secret);                                                                                                            
  $auth_header_value = "{$endpoint}|{$time}|{$hash}";                                                                                                                         
  Or just return true from rest-api.php:verify_authorization method                                                                                                           
                                                                                                                                                                              
  1. Block the test user:                                                                                                                                                     
  wp-env run cli wp user meta add {USER_ID} is_blocked_from_purchases true                                                                                                    
                                                                                                                                                                              
  2. Send manual decision:                                                                                                                                                    
  curl --location 'https://{SFW_INSTANCE_URL}/wp-json/sift-for-woocommerce/v1/fraud/users/{USER_ID}/decision' \                                                               
  --header 'Authorization: {AUTH_HEADER}' \                                                                                                                                   
  --header 'Content-Type: application/json' \                                                                                                                                 
  --data '{                                                                                                                                                                   
      "decision_id": "looks_good_payment_abuse",                                                                                                                              
      "description": "Manual review - clearing block",                                                                                                                        
      "analyst": "test_analyst"                                                                                                                                               
  }'                                                                                                                                                                          
                                                                                                                                                                              
  3. Verify user is unblocked:                                                                                                                                                
  wp-env run cli wp user meta get {USER_ID} is_blocked_from_purchases                                                                                                         
  **Expected:** "" (meta deleted, user unblocked)                                                                                                                             
  4. Check decision logged to Sift console:                                                                                                                                   
    - https://console.sift.com/developer/api-logs?abuse_type=payment_abuse&type=decision                                                                                      
  5. Check last decision stored:                                                                                                                                              
  wp-env run cli wp user meta get {USER_ID} sfw_fraud_risk_decision                                                                                                           
  **Expected:** "looks_good_payment_abuse"                                                                                                                                            
 6. Check the user meta is_blocked_from_purchases or search for the user in the Customer Overview widget at /wp-admin                    
                                                                                                                                                          
  Before Fix                                                                                                                                                                  
                                                                                                                                                                              
  - Automated webhook unblocks user                                                                                                                                           
                                                                                                                                                                              
  After Fix                                                                                                                                                                   
                                                                                                                                                                              
  - Automated webhook logs only, user stays blocked                                                                                                                           
  - Manual API still unblocks                                                                                                                                                 
                                      



