### PR TITLE
Fix undefined method error when Store API SessionHandler is used for Sift events

### DIFF
--- a/src/inc/sift-events/sift-events.php
+++ b/src/inc/sift-events/sift-events.php
@@ -117,7 +117,7 @@ class Events {
 		$user       = wp_get_current_user();
 		$properties = array(
 			'$user_id'    => self::format_user_id( $user->ID ?? 0 ),
-			'$session_id' => \WC()->session?->get_customer_unique_id() ?? '',
+			'$session_id' => self::get_session_id(),
 			'$promotions' => array(
 				array(
 					'$promotion_id' => $coupon_code,
@@ -149,9 +149,9 @@ class Events {
 		}
 
 		$properties = array(
-			'$user_id'       => self::format_user_id( $user->ID ),
+			'$user_id'       => self::format_user_id( $user->ID ?? 0 ),
 			'$login_status'  => '$success',
-			'$session_id'    => \WC()->session?->get_customer_unique_id() ?? '',
+			'$session_id'    => self::get_session_id(),
 			'$user_email'    => $user->user_email ?? null,
 			'$browser'       => self::get_client_browser(), // alternately, `$app` for details of the app if not a browser.
 			'$username'      => $username,
@@ -203,7 +203,7 @@ class Events {
 		$properties = array(
 			'$user_id'      => self::format_user_id( $user_id ),
 			'$login_status' => '$failure',
-			'$session_id'   => \WC()->session?->get_customer_unique_id() ?? '',
+			'$session_id'   => self::get_session_id(),
 			'$browser'      => self::get_client_browser(), // alternately, `$app` for details of the app if not a browser.
 			'$username'     => $username,
 			'$ip'           => self::get_client_ip(),
@@ -235,8 +235,8 @@ class Events {
 		$user = get_user_by( 'id', $user_id );
 
 		$properties = array(
-			'$user_id'      => self::format_user_id( $user->ID ),
-			'$session_id'   => \WC()->session?->get_customer_unique_id() ?? '',
+			'$user_id'      => self::format_user_id( $user->ID ?? 0 ),
+			'$session_id'   => self::get_session_id(),
 			'$user_email'   => $user->user_email ? $user->user_email : null,
 			// '$referrer_user_id' => ??? -- required for detecting referral fraud, but non-standard to woocommerce.
 			'$browser'      => self::get_client_browser(),
@@ -280,7 +280,7 @@ class Events {
 			'$user_id'      => self::format_user_id( $user->ID ),
 			'$user_email'   => $user->user_email ? $user->user_email : null,
 			// '$referrer_user_id' => ??? -- required for detecting referral fraud, but non-standard to woocommerce.
-			'$session_id'   => \WC()->session?->get_customer_unique_id() ?? '',
+			'$session_id'   => self::get_session_id(),
 			'$browser'      => self::get_client_browser(),
 			'$site_domain'  => wp_parse_url( site_url(), PHP_URL_HOST ),
 			'$site_country' => wc_get_base_location()['country'],
@@ -378,7 +378,7 @@ class Events {
 		$properties = array(
 			'$user_id'      => self::format_user_id( $user->ID ?? 0 ),
 			'$user_email'   => $user->user_email ?? null,
-			'$session_id'   => \WC()->session?->get_customer_unique_id() ?? '',
+			'$session_id'   => self::get_session_id(),
 			'$item'         => array(
 				'$item_id'   => (string) $cart_item_key,
 				'product_id' => $product->get_id(), // Store product ID for later lookup (no $ prefix - internal use)
@@ -424,7 +424,7 @@ class Events {
 		$properties = array(
 			'$user_id'      => self::format_user_id( $user->ID ?? 0 ),
 			'$user_email'   => $user->user_email ? $user->user_email : null,
-			'$session_id'   => \WC()->session?->get_customer_unique_id() ?? '',
+			'$session_id'   => self::get_session_id(),
 			'$item'         => array(
 				'$item_id'   => (string) $product->get_id(),
 				'product_id' => $product->get_id(), // Store product ID for later lookup (no $ - internal use)
@@ -491,7 +491,7 @@ class Events {
 		}
 
 		$properties = array(
-			'$session_id' => WC()->session?->get_customer_unique_id() ?? '',
+			'$session_id' => self::get_session_id(),
 			'$order_id'   => (string) $order->get_id(),
 			'$user_id'    => self::format_user_id( $order->get_user_id() ),
 			'$browser'    => self::get_client_browser(),
@@ -536,7 +536,7 @@ class Events {
 
 		$properties = array(
 			'$user_id'            => self::format_user_id( $order->get_user_id() ),
-			'$session_id'         => \WC()->session?->get_customer_unique_id() ?? '',
+			'$session_id'         => self::get_session_id(),
 			'$amount'             => self::get_transaction_micros( floatval( $order->get_total() ) ), // Gotta multiply it up to give an integer.
 			'$currency_code'      => $order->get_currency(),
 			'$order_id'           => (string) $order->get_id(),
@@ -579,7 +579,7 @@ class Events {
 
 		$properties = array(
 			'$user_id'      => self::format_user_id( $order->get_user_id() ),
-			'$session_id'   => \WC()->session?->get_customer_unique_id() ?? '',
+			'$session_id'   => self::get_session_id(),
 			'$order_id'     => $order_id,
 			'$source'       => $status_transition['manual'] ? '$manual_review' : '$automated',
 			'$description'  => $status_transition['note'],
@@ -996,6 +996,34 @@ class Events {
 		}
 
 		return $client_ip;
+	}
+
+	/**
+	 * Safely get the WooCommerce session ID.
+	 *
+	 * The standard WC_Session_Handler has get_customer_unique_id(), but the
+	 * Store API's SessionHandler (used by WooCommerce Blocks) does not.
+	 * This method safely handles both cases by falling back to get_customer_id()
+	 * which is defined in the abstract WC_Session base class.
+	 *
+	 * @return string The session ID, or empty string if unavailable.
+	 */
+	private static function get_session_id(): string {
+		$session = \WC()->session ?? null;
+
+		if ( null === $session ) {
+			return '';
+		}
+
+		// Prefer get_customer_unique_id() (standard WC_Session_Handler) as it has
+		// additional logic to return user ID when session isn't initialized.
+		if ( method_exists( $session, 'get_customer_unique_id' ) ) {
+			return $session->get_customer_unique_id();
+		}
+
+		// Fallback to get_customer_id() from abstract WC_Session base class.
+		// This works for Store API's SessionHandler and any custom handlers.
+		return (string) $session->get_customer_id();
 	}
 
 	/**

--- a/src/inc/tracking-js.php
+++ b/src/inc/tracking-js.php
@@ -26,7 +26,15 @@ function print_sift_tracking_js() {
 		$sift_user_id = apply_filters( 'sift_for_woocommerce_translate_user_id_for_decision', $wccom_user_id );
 	}
 
-	$session_id = WC()->session->get_customer_unique_id();
+	$session    = WC()->session ?? null;
+	$session_id = '';
+	if ( $session ) {
+		// Prefer get_customer_unique_id() (standard WC_Session_Handler), fallback to
+		// get_customer_id() for Store API's SessionHandler which doesn't have it.
+		$session_id = method_exists( $session, 'get_customer_unique_id' )
+			? $session->get_customer_unique_id()
+			: (string) $session->get_customer_id();
+	}
 	?>
 <script type="text/javascript">
 	var _sift = window._sift = window._sift || [];


### PR DESCRIPTION
Part of [#FRAUD-1312](https://linear.app/a8c/issue/FRAUD-132/sfw-fix-fatal-error-when-sift-events-fire-during-store-api-requests)
Related to: https://github.com/Automattic/woocommerce.com/pull/24909

### Description

The Sift integration was throwing fatal errors when WooCommerce Blocks/Store API checkout was used:                                           
                                                                                                                                                
  Uncaught exception 'Error' with message 'Call to undefined method Automattic\WooCommerce\StoreApi\SessionHandler::get_customer_unique_id()'   
                                                                                                                                                
  The issue is that `WC()->session` can return two different session handler implementations:                                                   
  - **`WC_Session_Handler`** (standard) - has `get_customer_unique_id()`                                                                        
  - **`Automattic\WooCommerce\StoreApi\SessionHandler`** (WooCommerce Blocks) - does NOT have this method                                       
                                                                                                                                                
  Both extend the abstract `WC_Session` class which provides `get_customer_id()`. The fix checks for the preferred method first and falls back to the base class method which is guaranteed to exist.                                                                                        
                                                                                                                                                
  In practice, both methods return the same session identifier when a session exists - `get_customer_unique_id()` just has additional fallback logic to return the WP user ID if the session isn't initialized yet. 

### Changes in this PR

  * Add `get_session_id()` helper method in `sift-events.php` that safely checks for `get_customer_unique_id()` before calling it, with fallback
   to `get_customer_id()`                                                                                                                       
  * Update all 12 usages of `\WC()->session?->get_customer_unique_id()` to use the new helper                                                   
  * Fix `tracking-js.php` to use the same safe pattern inline        
  * Added null coalescing ($user->ID ?? 0) to prevent fatal errors if get_user_by() returns false

#### Testing instructions


### Test instructions

  1. Check out this branch on your local environment.                                                                                                        
  2. Follow the readme [here](https://github.com/woocommerce/sift-for-woocommerce/blob/trunk/README.md) to setup a Local Environment.
  3. Gather testing data:                                                                                                                                    
  {SFW_INSTANCE_URL}                                                                                                                                         
  - The url where you are running: staging.woocommerce.com/localhost/ngrok/jurassictube                                                                      
  - ex: foo-bar.ngrok-free.app                                                    
  4. Product ID: Use 11 (or whatever exists in the test env) instead of 3574673                                                                                     
  5. No ngrok header needed for jurassic.tube                                                                                                                       
                                                                                                                                                                    
  Steps:                                                                                                                    
                                                                                                                                                                    
  # Get a fresh cart token                                                                                                                                          
  export TOKEN=$(curl -sI "https://{SFW_INSTANCE_URL}/wp-json/wc/store/v1/cart" | grep -i "cart-token:" | cut -d' ' -f2 | tr -d '\r')                               
  echo "Token: $TOKEN"                                                                                                                                              
                                                                                                                                                                    
  # Get a valid product ID                                                                                                                                          
  PRODUCT_ID=$(curl -s "https://{SFW_INSTANCE_URL}/wp-json/wc/store/v1/products?per_page=1" | jq '.[0].id')                                                         
  echo "Product ID: $PRODUCT_ID"                                                                                                                                    
                                                                                                                                                                    
  # Test 1: Add to Cart                                                                                                                                             
  curl -s -X POST "https://{SFW_INSTANCE_URL}/wp-json/wc/store/v1/cart/add-item" \                                                                                  
    -H "Content-Type: application/json" \                                                                                                                           
    -H "Cart-Token: $TOKEN" \                                                                                                                                       
    -d "{\"id\": $PRODUCT_ID, \"quantity\": 1}" | head -c 200                                                                                                       
                                                                                                                                                                    
  # Test 2: Remove from Cart                                                                                                                                        
  KEY=$(curl -s "https://{SFW_INSTANCE_URL}/wp-json/wc/store/v1/cart" -H "Cart-Token: $TOKEN" | jq -r '.items[0].key')                                              
  curl -s -X POST "https://{SFW_INSTANCE_URL}/wp-json/wc/store/v1/cart/remove-item" \                                                                               
    -H "Content-Type: application/json" \                                                                                                                           
    -H "Cart-Token: $TOKEN" \                                                                                                                                       
    -d "{\"key\": \"$KEY\"}" | head -c 200   


Expected Results                                                                                                                                               
                                                                                                                                                                    
  Before Fix:
```
  {                                                                                                                                                                 
    "code": "qm_fatal",                                                                                                                                             
    "message": "Uncaught Error: Call to undefined method Automattic\\WooCommerce\\StoreApi\\SessionHandler::get_customer_unique_id() in .../sift-events.php on line 
  381"                                                                                                                                                              
  }                                                                                                                                                                 
```                                                                                                                                                               
  After Fix:                                                                                                                                                        
```
  {                                                                                                                                                                 
    "items": [{"key": "...", "id": 12345, "quantity": 1, ...}],                                                                                                     
    "totals": {...}                                                                                                                                                 
  }  
```                                                                                                                                                               

Log validation: `npx wp-env run cli tail -f /var/www/html/wp-content/debug.log`
Sift Activity: `https://console.sift.com/users/{$USERID}/activity?abuse_type=payment_abuse`


