### PR TITLE
Add WP-CLI event suppression to prevent CLI-triggered Sift events

### DIFF
--- a/src/inc/sift-events/class-sift-event-types.php
+++ b/src/inc/sift-events/class-sift-event-types.php
@@ -202,6 +202,11 @@ class Sift_Event_Types {
 	 * @return boolean
 	 */
 	public static function can_event_be_sent( string $event_type ) {
+		// Suppress events when running under WP-CLI (no real user session).
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			return false;
+		}
+
 		$event_disabled_filter = self::get_filter_for_disabled_event_type( $event_type );
 
 		$disabled = apply_filters( $event_disabled_filter, false ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.DynamicHooknameFound


### PR DESCRIPTION
## Summary

WP-CLI commands that trigger WooCommerce order/user hooks fire Sift fraud-detection events even though there is no real user session. On woocommerce.com this accounted for ~33% of all queued Sift events (567,945 out of 1,687,945). We [applied the same patch](https://github.com/Automattic/woocommerce.com/pull/25203) on woocommerce.com and thought it could benefit the upstream plugin as well. 

Linear issue: https://linear.app/a8c/issue/WCCOM-2368/audit-when-async-sift-for-woocommerce-send-event-runs

## Changes

Adds a guard inside to suppress events when running under WP-CLI.

## Benefits

- Any store running WP-CLI batch jobs (imports, renewals, migrations) will benefit
- Reduces noise in Sift fraud detection from non-user actions
- Minimal, targeted fix with no impact on browser-initiated events

## Testing

- WP-CLI-triggered events no longer queued in Action Scheduler when running under CLI
- Browser-initiated events (real user sessions) continue to be sent normally