### PR TITLE
Backport inline Sift decisions and E2E user skip from woocommerce.com

### DIFF
--- a/src/inc/sift-events/class-sift-event-types.php
+++ b/src/inc/sift-events/class-sift-event-types.php
@@ -207,6 +207,11 @@ class Sift_Event_Types {
 			return false;
 		}
 
+		$should_skip_user = apply_filters( 'sift_for_woocommerce_should_skip_user', false );
+		if ( $should_skip_user ) {
+			return false;
+		}
+
 		$event_disabled_filter = self::get_filter_for_disabled_event_type( $event_type );
 
 		$disabled = apply_filters( $event_disabled_filter, false ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.DynamicHooknameFound

--- a/src/inc/sift-events/sift-events.php
+++ b/src/inc/sift-events/sift-events.php
@@ -683,50 +683,48 @@ class Events {
 	}
 
 	/**
-	 * Get any new abuse decisions for a user, and apply it if needed.
+	 * Extract the most severe payment_abuse decision ID from a Sift track() response
+	 * that was sent with return_workflow_status=true.
 	 *
-	 * @param string $sift_user_id  The user ID sent to Sift, usually the WPCOM user ID.
-	 * @param string $wccom_user_id The WooCommerce user ID.
+	 * Parses the workflow_statuses array in the score_response to collect all decision
+	 * IDs, then returns the most severe one using the filterable severity list.
 	 *
-	 * @return string|null
+	 * @param \SiftResponse $response The response from $client->track().
+	 *
+	 * @return string|null The most severe decision ID, or null if none found.
 	 */
-	public static function get_decision( string $sift_user_id, string $wccom_user_id ): ?string {
-		$client = \Sift_For_WooCommerce\Sift_For_WooCommerce::get_api_client();
-		if ( empty( $client ) ) {
-			Sift_For_WooCommerce::log(
-				'Failed to get the Sift API client.',
-				'error',
-				array(
-					'source' => 'sift-events',
-				)
-			);
+	public static function extract_decision_from_response( \SiftResponse $response ): ?string {
+		$workflow_statuses = $response->body['score_response']['workflow_statuses'] ?? null;
+
+		if ( empty( $workflow_statuses ) || ! is_array( $workflow_statuses ) ) {
+			return null;
+		}
+		// Collect all decision IDs from workflow history entries.
+		$decision_ids = array();
+		foreach ( $workflow_statuses as $status ) {
+			if ( ( $status['history'][0]['app'] ?? '' ) === 'decision'
+				&& isset( $status['history'][0]['config']['decision_id'] )
+			) {
+				$decision_ids[] = $status['history'][0]['config']['decision_id'];
+			}
+		}
+
+		if ( empty( $decision_ids ) ) {
 			return null;
 		}
 
-		// Get the abuse decision from Sift.
-		$user_decisions_response = $client->getUserDecisions( $sift_user_id );
+		// Platform defines severity ordering via filter (most severe first).
+		$severity_order = apply_filters( 'sift_for_woocommerce_decision_ids_by_severity', array() );
 
-		$decision_id = null;
-
-		// If $user_decisions_response->body['decisions'] is empty, log the info.
-		if ( empty( $user_decisions_response->body['decisions'] ) ) {
-			Sift_For_WooCommerce::log(
-				'No decisions found for user',
-				'info',
-				array(
-					'source'       => 'sift-events',
-					'sift_user_id' => $sift_user_id,
-				)
-			);
-			return null;
+		// Return the most severe decision when multiple workflows fire.
+		foreach ( $severity_order as $decision_id ) {
+			if ( in_array( $decision_id, $decision_ids, true ) ) {
+				return $decision_id;
+			}
 		}
 
-		// Extract the decision ID for payment abuse if it exists.
-		if ( isset( $user_decisions_response->body['decisions']['payment_abuse']['decision']['id'] ) ) {
-			$decision_id = $user_decisions_response->body['decisions']['payment_abuse']['decision']['id'];
-		}
-
-		return self::apply_decision( $decision_id, $wccom_user_id );
+		// No recognised decision in severity list - return first found.
+		return $decision_ids[0];
 	}
 
 	/**
@@ -933,8 +931,15 @@ class Events {
 			return false;
 		}
 
-		// Send to Sift API
-		$response = $client->track( $event, $properties );
+		// Only request inline workflow decisions when there's a user ID,
+		// since decisions are per-user.
+		$sift_user_id  = $properties['$user_id'] ?? null;
+		$track_options = array();
+		if ( $sift_user_id ) {
+			$track_options['return_workflow_status'] = true;
+			$track_options['abuse_types']            = array( 'payment_abuse' );
+		}
+		$response = $client->track( $event, $properties, $track_options );
 
 		if ( 200 !== $response->httpStatusCode ) {
 			Sift_For_WooCommerce::log(
@@ -949,14 +954,12 @@ class Events {
 			return false;
 		}
 
-		// Get decisions if user ID is available
-		$sift_user_id = $properties['$user_id'] ?? null;
-
-		// Get the current decision since events have been sent and could have changed the decision.
-		// This is only done if the user ID is set.
+		// Extract and apply inline decision from the track() response if available.
 		if ( $sift_user_id ) {
-			// Get the decision for the user and apply if needed.
-			self::get_decision( $sift_user_id, $sift_user_id );
+			$decision_id = self::extract_decision_from_response( $response );
+			if ( $decision_id ) {
+				self::apply_decision( $decision_id, $sift_user_id );
+			}
 		}
 
 		return true;

--- a/src/inc/tracking-js.php
+++ b/src/inc/tracking-js.php
@@ -21,6 +21,11 @@ function print_sift_tracking_js() {
 
 	$sift_user_id = null;
 	if ( is_user_logged_in() ) {
+		$should_skip = apply_filters( 'sift_for_woocommerce_should_skip_user', false );
+		if ( $should_skip ) {
+			return null;
+		}
+
 		$wccom_user_id = get_current_user_id();
 		// Translate WC user ID to Sift user ID (wpcom or prefixed wccom ID)
 		$sift_user_id = apply_filters( 'sift_for_woocommerce_translate_user_id_for_decision', $wccom_user_id );

--- a/tests/DisabledEventTest.php
+++ b/tests/DisabledEventTest.php
@@ -131,6 +131,35 @@ class DisabledEventTest extends EventTest {
 	}
 
 	/**
+	 * Test that the should_skip_user filter blocks all events.
+	 *
+	 * @return void
+	 */
+	public function test_skip_user_filter() {
+		// Events should send normally.
+		Events::update_password( 'test', '1' );
+		self::fail_on_error_logged();
+		self::assertEventSent( Sift_Event_Types::$update_password );
+
+		self::reset_events();
+
+		// Enable the skip filter.
+		add_filter( 'sift_for_woocommerce_should_skip_user', '__return_true' );
+		Events::update_password( 'test', '1' );
+		self::fail_on_error_logged();
+		self::assertNoEventSent( Sift_Event_Types::$update_password );
+
+		// Remove the skip filter - events should send again.
+		remove_filter( 'sift_for_woocommerce_should_skip_user', '__return_true' );
+
+		self::reset_events();
+
+		Events::update_password( 'test', '1' );
+		self::fail_on_error_logged();
+		self::assertEventSent( Sift_Event_Types::$update_password );
+	}
+
+	/**
 	 * Test that the $or event is triggered.
 	 *
 	 * @return void

--- a/tests/ExtractDecisionFromResponseTest.php
+++ b/tests/ExtractDecisionFromResponseTest.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * Class ExtractDecisionFromResponseTest
+ *
+ * @package Sift_For_WooCommerce
+ */
+declare( strict_types=1 );
+
+// phpcs:disable Universal.Arrays.DisallowShortArraySyntax.Found, WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound
+
+use Sift_For_WooCommerce\Sift_Events\Events;
+
+/**
+ * Tests for Events::extract_decision_from_response().
+ */
+class ExtractDecisionFromResponseTest extends WP_UnitTestCase {
+
+	/**
+	 * Clean up filters after each test to prevent leaks.
+	 *
+	 * @return void
+	 */
+	public function tear_down() {
+		remove_all_filters( 'sift_for_woocommerce_decision_ids_by_severity' );
+		parent::tear_down();
+	}
+
+	/**
+	 * Helper to build a SiftResponse with a given body.
+	 *
+	 * @param array $body The response body.
+	 *
+	 * @return \SiftResponse
+	 */
+	private function make_response( array $body ): \SiftResponse {
+		$response       = new \SiftResponse( wp_json_encode( $body ), 200, '' );
+		$response->body = $body;
+		return $response;
+	}
+
+	/**
+	 * Test returns null when score_response is missing.
+	 *
+	 * @return void
+	 */
+	public function test_returns_null_when_no_score_response() {
+		$response = $this->make_response( array( 'status' => 0 ) );
+		$this->assertNull( Events::extract_decision_from_response( $response ) );
+	}
+
+	/**
+	 * Test returns null when workflow_statuses is empty.
+	 *
+	 * @return void
+	 */
+	public function test_returns_null_when_workflow_statuses_empty() {
+		$response = $this->make_response(
+			array(
+				'score_response' => array(
+					'workflow_statuses' => array(),
+				),
+			)
+		);
+		$this->assertNull( Events::extract_decision_from_response( $response ) );
+	}
+
+	/**
+	 * Test returns null when workflow history has no decision entries.
+	 *
+	 * @return void
+	 */
+	public function test_returns_null_when_no_decision_in_history() {
+		$response = $this->make_response(
+			array(
+				'score_response' => array(
+					'workflow_statuses' => array(
+						array(
+							'history' => array(
+								array(
+									'app'    => 'some_other_workflow',
+									'config' => array( 'decision_id' => 'irrelevant' ),
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+		$this->assertNull( Events::extract_decision_from_response( $response ) );
+	}
+
+	/**
+	 * Test returns the decision ID when a single decision is present.
+	 *
+	 * @return void
+	 */
+	public function test_returns_single_decision() {
+		$response = $this->make_response(
+			array(
+				'score_response' => array(
+					'workflow_statuses' => array(
+						array(
+							'history' => array(
+								array(
+									'app'    => 'decision',
+									'config' => array( 'decision_id' => 'block_user_payment_abuse' ),
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+		$this->assertSame( 'block_user_payment_abuse', Events::extract_decision_from_response( $response ) );
+	}
+
+	/**
+	 * Test returns first decision when multiple decisions exist but no severity filter is hooked.
+	 *
+	 * @return void
+	 */
+	public function test_returns_first_decision_without_severity_filter() {
+		$response = $this->make_response(
+			array(
+				'score_response' => array(
+					'workflow_statuses' => array(
+						array(
+							'history' => array(
+								array(
+									'app'    => 'decision',
+									'config' => array( 'decision_id' => 'watch_user' ),
+								),
+							),
+						),
+						array(
+							'history' => array(
+								array(
+									'app'    => 'decision',
+									'config' => array( 'decision_id' => 'block_user' ),
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+		$this->assertSame( 'watch_user', Events::extract_decision_from_response( $response ) );
+	}
+
+	/**
+	 * Test returns most severe decision when severity filter is hooked.
+	 *
+	 * @return void
+	 */
+	public function test_returns_most_severe_decision_with_severity_filter() {
+		$severity_callback = function () {
+			return array( 'block_user', 'watch_user' );
+		};
+		add_filter( 'sift_for_woocommerce_decision_ids_by_severity', $severity_callback );
+
+		$response = $this->make_response(
+			array(
+				'score_response' => array(
+					'workflow_statuses' => array(
+						array(
+							'history' => array(
+								array(
+									'app'    => 'decision',
+									'config' => array( 'decision_id' => 'watch_user' ),
+								),
+							),
+						),
+						array(
+							'history' => array(
+								array(
+									'app'    => 'decision',
+									'config' => array( 'decision_id' => 'block_user' ),
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+		$this->assertSame( 'block_user', Events::extract_decision_from_response( $response ) );
+	}
+}


### PR DESCRIPTION
Resolves FRAUD-152

Related Changes:
[#25231](https://github.com/Automattic/woocommerce.com/pull/25231)
[#25309](https://github.com/Automattic/woocommerce.com/pull/25309)

## Summary

Backports two improvements from the woocommerce.com integration to the upstream plugin:

1. **Inline Sift decisions** - Replaces the separate `getUserDecisions()` API call with inline workflow decisions from the `track()` response. This eliminates one API round-trip per event by passing `return_workflow_status=true` to the track call and parsing decisions from the response directly.

2. **Skip Sift events for filtered users** - Adds a `sift_for_woocommerce_should_skip_user` filter that platforms can hook into to skip both server-side events and the JavaScript beacon for specific users (e.g., E2E test accounts). This prevents test automation from polluting Sift fraud models.

## Changes

- Replace `get_decision()` (which called `getUserDecisions()`) with `extract_decision_from_response()` that parses inline workflow statuses
- Pass `return_workflow_status` and `abuse_types` options to `$client->track()` when a user ID is present
- Add `sift_for_woocommerce_decision_ids_by_severity` filter for platforms to define decision severity ordering
- Add `sift_for_woocommerce_should_skip_user` filter check in `can_event_be_sent()` and `print_sift_tracking_js()`

## Benefits

- Eliminates a separate Sift API call per event - decisions come back inline with the track response
- Supports multiple workflow decisions with configurable severity ordering
- Platforms can filter out test/bot users from Sift entirely, keeping fraud models clean
- Both features are behind filters with sensible defaults, so existing installations are unaffected

## Testing

- Verify server-side events still send and decisions still apply after the inline change
- Hook `sift_for_woocommerce_should_skip_user` to return `true` for a test user and verify no events are sent (server-side or JS beacon)
- Verify that when `sift_for_woocommerce_should_skip_user` returns `false` (default), events send normally
- Verify events still send and decisions still apply when configured events fire
