### PR TITLE
chore: pin third-party GitHub Actions to SHAs + enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,4 +20,3 @@ updates:
           - "major"
     cooldown:
       default-days: 7
-      semver-major-days: 14

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Setup proper PHP version
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: ${{ matrix.php }}
           tools: composer

--- a/.github/workflows/php-syntax-errors.yml
+++ b/.github/workflows/php-syntax-errors.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Setup proper PHP version
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: ${{ matrix.php }}
 


### PR DESCRIPTION
Pins third-party GitHub Actions to commit SHAs and adds Dependabot coverage for the `github-actions` ecosystem.

Tracking: DEVPROD-1073

Verification commands:

```bash
# shivammathur/setup-php # 2.37.1
gh api repos/shivammathur/setup-php/commits/2.37.1 --jq '{ref:"2.37.1",resolved_sha:.sha,expected_sha:"7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc",matches:(.sha=="7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc")}'
```

Dependabot: created .github/dependabot.yml.
