### PR TITLE
Protect manual fraud decisions from Sift automation

### DIFF
--- a/src/inc/sift-decisions/abuse-decisions.php
+++ b/src/inc/sift-decisions/abuse-decisions.php
@@ -4,7 +4,9 @@ namespace Sift_For_WooCommerce\Abuse_Decisions;
 
 require_once __DIR__ . '/sift-decision-rest-api-webhooks.php';
 
-const USER_FRAUD_DECISION_META_KEY = 'sfw_fraud_risk_decision';
+const USER_FRAUD_DECISION_META_KEY      = 'sfw_fraud_risk_decision';
+const USER_FRAUD_REVIEW_BYPASS_META_KEY = 'sfw_fraud_review_bypass';
+const USER_FRAUDSTER_FLAG_META_KEY      = 'sfw_fraudster_flag';
 
 /**
  * Process the Sift decision received.
@@ -35,6 +37,37 @@ function process_sift_decision_received( $return_value, $decision_id, $user_id )
 		);
 
 		return $woocommerce_user_id;
+	}
+
+	// Trusted users (bypass flag) are never touched by automated decisions.
+	if ( has_fraud_review_bypass( (int) $woocommerce_user_id ) ) {
+		wc_get_logger()->log(
+			'info',
+			"Automated decision '{$decision_id}' skipped for user {$woocommerce_user_id}: fraud review bypass active",
+			array(
+				'source'              => 'sift-for-woocommerce',
+				'decision_id'         => $decision_id,
+				'sift_user_id'        => $user_id,
+				'woocommerce_user_id' => $woocommerce_user_id,
+			)
+		);
+		return $return_value;
+	}
+
+	// Confirmed fraudster - manually applied, so skip all automation (no re-block, downgrade,
+	// or unblock), same as the bypass flag.
+	if ( has_fraudster_flag( (int) $woocommerce_user_id ) ) {
+		wc_get_logger()->log(
+			'info',
+			"Automated decision '{$decision_id}' skipped for user {$woocommerce_user_id}: fraudster flag active",
+			array(
+				'source'              => 'sift-for-woocommerce',
+				'decision_id'         => $decision_id,
+				'sift_user_id'        => $user_id,
+				'woocommerce_user_id' => $woocommerce_user_id,
+			)
+		);
+		return $return_value;
 	}
 
 	// Checkbox options are "yes" or "no" values
@@ -133,29 +166,41 @@ function process_manual_fraud_decision( string $woocommerce_user_id, string $dec
 	switch ( $decision_id ) {
 		case 'trust_list_payment_abuse':
 			do_action( 'sift_for_woocommerce_trust_list_payment_abuse', $woocommerce_user_id );
+			apply_fraud_review_bypass( (int) $woocommerce_user_id, $analyst );
+			remove_fraudster_flag( (int) $woocommerce_user_id, $analyst );
 			break;
 
 		case 'looks_good_payment_abuse':
 			do_action( 'sift_for_woocommerce_looks_good_payment_abuse', $woocommerce_user_id, false );
+			remove_fraud_review_bypass( (int) $woocommerce_user_id, $analyst );
+			remove_fraudster_flag( (int) $woocommerce_user_id, $analyst );
 			break;
 
 		case 'not_likely_fraud_payment_abuse':
 			do_action( 'sift_for_woocommerce_not_likely_fraud_payment_abuse', $woocommerce_user_id );
+			remove_fraud_review_bypass( (int) $woocommerce_user_id, $analyst );
+			remove_fraudster_flag( (int) $woocommerce_user_id, $analyst );
 			break;
 
 		case 'likely_fraud_no_purchases_payment_abuse_1':
 			do_action( 'sift_for_woocommerce_likely_fraud_refundno_renew_payment_abuse', $woocommerce_user_id );
+			remove_fraud_review_bypass( (int) $woocommerce_user_id, $analyst );
+			remove_fraudster_flag( (int) $woocommerce_user_id, $analyst );
 			break;
 
 		case 'likely_fraud_keep_purchases_payment_abuse':
 		case 'likely_fraud_block_keep_purch_payment_abuse':
-			// Normalize descision_id
+			// Normalize decision_id
 			$decision_id = 'likely_fraud_block_keep_purch_payment_abuse';
 			do_action( 'sift_for_woocommerce_likely_fraud_keep_purchases_payment_abuse', $woocommerce_user_id );
+			remove_fraud_review_bypass( (int) $woocommerce_user_id, $analyst );
+			remove_fraudster_flag( (int) $woocommerce_user_id, $analyst );
 			break;
 
 		case 'fraud_payment_abuse':
 			do_action( 'sift_for_woocommerce_fraud_payment_abuse', $woocommerce_user_id );
+			apply_fraudster_flag( (int) $woocommerce_user_id, $analyst );
+			remove_fraud_review_bypass( (int) $woocommerce_user_id, $analyst );
 			break;
 
 		default:
@@ -253,10 +298,10 @@ function send_decision_to_sift(
 	string $decision_id,
 	string $description,
 	string $analyst
-): \SiftResponse {
+): ?\SiftResponse {
 	$client = \Sift_For_WooCommerce\Sift_For_WooCommerce::get_api_client();
 	if ( empty( $client ) ) {
-		Sift_For_WooCommerce::log(
+		\Sift_For_WooCommerce\Sift_For_WooCommerce::log(
 			'Failed to get the Sift API client.',
 			'error',
 			array(
@@ -298,3 +343,115 @@ function send_decision_to_sift(
 	return $response;
 }
 add_filter( 'sift_for_woocommerce_send_decision_to_sift', __NAMESPACE__ . '\send_decision_to_sift', 10, 4 );
+
+/**
+ * Check if a user has the fraud review bypass flag (trusted user).
+ *
+ * @param integer $user_id WooCommerce user ID.
+ *
+ * @return boolean True if the bypass flag is set.
+ */
+function has_fraud_review_bypass( int $user_id ): bool {
+	return (bool) get_user_meta( $user_id, USER_FRAUD_REVIEW_BYPASS_META_KEY, true );
+}
+
+/**
+ * Set the fraud review bypass flag (mark a user as trusted).
+ *
+ * @param integer $user_id WooCommerce user ID.
+ * @param string  $analyst Username of the analyst making the decision.
+ *
+ * @return void
+ */
+function apply_fraud_review_bypass( int $user_id, string $analyst ): void {
+	update_user_meta( $user_id, USER_FRAUD_REVIEW_BYPASS_META_KEY, true );
+	wc_get_logger()->log(
+		'info',
+		"Fraud review bypass applied for user {$user_id} by {$analyst}",
+		array(
+			'source'              => 'sift-for-woocommerce',
+			'woocommerce_user_id' => $user_id,
+			'by_user_id'          => $analyst,
+		)
+	);
+}
+
+/**
+ * Remove the fraud review bypass flag.
+ *
+ * @param integer $user_id WooCommerce user ID.
+ * @param string  $analyst Username of the analyst making the decision.
+ *
+ * @return void
+ */
+function remove_fraud_review_bypass( int $user_id, string $analyst ): void {
+	// Only log when a flag was actually there, so we don't pollute the audit trail.
+	if ( ! delete_user_meta( $user_id, USER_FRAUD_REVIEW_BYPASS_META_KEY ) ) {
+		return;
+	}
+	wc_get_logger()->log(
+		'info',
+		"Fraud review bypass removed for user {$user_id} by {$analyst}",
+		array(
+			'source'              => 'sift-for-woocommerce',
+			'woocommerce_user_id' => $user_id,
+			'by_user_id'          => $analyst,
+		)
+	);
+}
+
+/**
+ * Check if a user has the fraudster flag (confirmed fraud).
+ *
+ * @param integer $user_id WooCommerce user ID.
+ *
+ * @return boolean True if the fraudster flag is set.
+ */
+function has_fraudster_flag( int $user_id ): bool {
+	return (bool) get_user_meta( $user_id, USER_FRAUDSTER_FLAG_META_KEY, true );
+}
+
+/**
+ * Set the fraudster flag (mark a user as confirmed fraud).
+ *
+ * @param integer $user_id WooCommerce user ID.
+ * @param string  $analyst Username of the analyst making the decision.
+ *
+ * @return void
+ */
+function apply_fraudster_flag( int $user_id, string $analyst ): void {
+	update_user_meta( $user_id, USER_FRAUDSTER_FLAG_META_KEY, true );
+	wc_get_logger()->log(
+		'info',
+		"Fraudster flag applied for user {$user_id} by {$analyst}",
+		array(
+			'source'              => 'sift-for-woocommerce',
+			'woocommerce_user_id' => $user_id,
+			'by_user_id'          => $analyst,
+		)
+	);
+}
+
+/**
+ * Remove the fraudster flag.
+ *
+ * @param integer $user_id WooCommerce user ID.
+ * @param string  $analyst Username of the analyst making the decision.
+ *
+ * @return void
+ */
+function remove_fraudster_flag( int $user_id, string $analyst ): void {
+	// Only log when a flag was actually there, so we don't pollute the audit trail.
+	if ( ! delete_user_meta( $user_id, USER_FRAUDSTER_FLAG_META_KEY ) ) {
+		return;
+	}
+	wc_get_logger()->log(
+		'info',
+		"Fraudster flag removed for user {$user_id} by {$analyst}",
+		array(
+			'source'              => 'sift-for-woocommerce',
+			'woocommerce_user_id' => $user_id,
+			'by_user_id'          => $analyst,
+		)
+	);
+}

--- a/tests/FraudProtectionFlagsTest.php
+++ b/tests/FraudProtectionFlagsTest.php
@@ -1,0 +1,407 @@
+<?php
+/**
+ * Class Fraud_Protection_Flags_Test
+ *
+ * Tests for fraud protection flags (bypass and fraudster flags).
+ *
+ * @package Sift_For_WooCommerce
+ */
+
+declare( strict_types=1 );
+
+// phpcs:disable
+
+use Sift_For_WooCommerce\Abuse_Decisions;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Test fraud protection flags (bypass and fraudster flags).
+ */
+class Fraud_Protection_Flags_Test extends \WP_UnitTestCase {
+
+	/**
+	 * Test user ID.
+	 *
+	 * @var int
+	 */
+	private $test_user_id;
+
+	/**
+	 * Set up test fixtures.
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->test_user_id = wp_create_user( uniqid( 'testuser_', true ), 'password' );
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		// Clean up filters added during tests
+		remove_all_filters( 'sift_for_woocommerce_pre_sift_decision' );
+		remove_all_actions( 'sift_for_woocommerce_block_wo_review_payment_abuse' );
+		remove_all_filters( 'woocommerce_logger_log_message' );
+
+		// Reset option so tests that set it don't bleed into tests that don't
+		delete_option( 'wc_sift_for_woocommerce_automated_actions_enabled' );
+
+		if ( $this->test_user_id ) {
+			wp_delete_user( $this->test_user_id );
+		}
+		parent::tearDown();
+	}
+
+	/**
+	 * Test fraud review bypass flag can be set, checked, and removed.
+	 *
+	 * @return void
+	 */
+	public function test_fraud_review_bypass_flag_lifecycle() {
+		// Initially no bypass flag
+		self::assertFalse( Abuse_Decisions\has_fraud_review_bypass( $this->test_user_id ) );
+
+		// Apply bypass flag
+		Abuse_Decisions\apply_fraud_review_bypass( $this->test_user_id, 'test_analyst' );
+		self::assertTrue( Abuse_Decisions\has_fraud_review_bypass( $this->test_user_id ) );
+
+		// Remove bypass flag
+		Abuse_Decisions\remove_fraud_review_bypass( $this->test_user_id, 'test_analyst' );
+		self::assertFalse( Abuse_Decisions\has_fraud_review_bypass( $this->test_user_id ) );
+	}
+
+	/**
+	 * Test fraudster flag can be set, checked, and removed.
+	 *
+	 * @return void
+	 */
+	public function test_fraudster_flag_lifecycle() {
+		// Initially no fraudster flag
+		self::assertFalse( Abuse_Decisions\has_fraudster_flag( $this->test_user_id ) );
+
+		// Apply fraudster flag
+		Abuse_Decisions\apply_fraudster_flag( $this->test_user_id, 'test_analyst' );
+		self::assertTrue( Abuse_Decisions\has_fraudster_flag( $this->test_user_id ) );
+
+		// Remove fraudster flag
+		Abuse_Decisions\remove_fraudster_flag( $this->test_user_id, 'test_analyst' );
+		self::assertFalse( Abuse_Decisions\has_fraudster_flag( $this->test_user_id ) );
+	}
+
+	/**
+	 * Test trust_list decision sets bypass flag and removes fraudster flag.
+	 *
+	 * @return void
+	 */
+	public function test_trust_list_decision_sets_bypass_removes_fraudster() {
+		// Set up: user has fraudster flag
+		Abuse_Decisions\apply_fraudster_flag( $this->test_user_id, 'setup' );
+
+		// Apply trust_list decision via the function
+		Abuse_Decisions\process_manual_fraud_decision(
+			(string) $this->test_user_id,
+			'trust_list_payment_abuse',
+			'Test description',
+			'test_analyst'
+		);
+
+		// Should have bypass flag, should NOT have fraudster flag
+		self::assertTrue( Abuse_Decisions\has_fraud_review_bypass( $this->test_user_id ) );
+		self::assertFalse( Abuse_Decisions\has_fraudster_flag( $this->test_user_id ) );
+	}
+
+	/**
+	 * Test fraud decision sets fraudster flag and removes bypass flag.
+	 *
+	 * @return void
+	 */
+	public function test_fraud_decision_sets_fraudster_removes_bypass() {
+		// Set up: user has bypass flag
+		Abuse_Decisions\apply_fraud_review_bypass( $this->test_user_id, 'setup' );
+
+		// Apply fraud decision via the function
+		Abuse_Decisions\process_manual_fraud_decision(
+			(string) $this->test_user_id,
+			'fraud_payment_abuse',
+			'Test description',
+			'test_analyst'
+		);
+
+		// Should have fraudster flag, should NOT have bypass flag
+		self::assertTrue( Abuse_Decisions\has_fraudster_flag( $this->test_user_id ) );
+		self::assertFalse( Abuse_Decisions\has_fraud_review_bypass( $this->test_user_id ) );
+	}
+
+	/**
+	 * Test looks_good decision clears both flags.
+	 *
+	 * @return void
+	 */
+	public function test_looks_good_decision_clears_both_flags() {
+		// Set up: user has both flags
+		Abuse_Decisions\apply_fraud_review_bypass( $this->test_user_id, 'setup' );
+		Abuse_Decisions\apply_fraudster_flag( $this->test_user_id, 'setup' );
+
+		// Apply looks_good decision
+		Abuse_Decisions\process_manual_fraud_decision(
+			(string) $this->test_user_id,
+			'looks_good_payment_abuse',
+			'Test description',
+			'test_analyst'
+		);
+
+		// Both flags should be cleared
+		self::assertFalse( Abuse_Decisions\has_fraud_review_bypass( $this->test_user_id ) );
+		self::assertFalse( Abuse_Decisions\has_fraudster_flag( $this->test_user_id ) );
+	}
+
+	/**
+	 * Test automated block decision is skipped when bypass flag is set.
+	 *
+	 * @return void
+	 */
+	public function test_automated_block_skipped_when_bypass_flag_set() {
+		// Set bypass flag
+		Abuse_Decisions\apply_fraud_review_bypass( $this->test_user_id, 'setup' );
+
+		// Track if action was fired
+		$action_fired = false;
+		add_action( 'sift_for_woocommerce_block_wo_review_payment_abuse', function() use ( &$action_fired ) {
+			$action_fired = true;
+		} );
+
+		// Enable automated actions
+		update_option( 'wc_sift_for_woocommerce_automated_actions_enabled', 'yes' );
+
+		// Mock user ID translation to return the test user ID directly
+		$test_user_id = $this->test_user_id;
+		add_filter( 'sift_for_woocommerce_pre_sift_decision', function( $user_id ) use ( $test_user_id ) {
+			return $test_user_id;
+		} );
+
+		// Call the function directly to test the flag check
+		Abuse_Decisions\process_sift_decision_received(
+			null,
+			'block_wo_review_payment_abuse',
+			(string) $this->test_user_id
+		);
+
+		// Action should NOT have fired because bypass flag is set
+		self::assertFalse( $action_fired, 'Automated block decision should be skipped when bypass flag is set' );
+	}
+
+	/**
+	 * Test automated block decision fires when no bypass flag is set.
+	 *
+	 * @return void
+	 */
+	public function test_automated_block_fires_when_no_bypass_flag() {
+		// Fresh user starts with no flags - no setup needed.
+
+		// Track if action was fired
+		$action_fired = false;
+		add_action( 'sift_for_woocommerce_block_wo_review_payment_abuse', function() use ( &$action_fired ) {
+			$action_fired = true;
+		} );
+
+		// Enable automated actions
+		update_option( 'wc_sift_for_woocommerce_automated_actions_enabled', 'yes' );
+
+		// Mock user ID translation to return the test user ID directly
+		$test_user_id = $this->test_user_id;
+		add_filter( 'sift_for_woocommerce_pre_sift_decision', function( $user_id ) use ( $test_user_id ) {
+			return $test_user_id;
+		} );
+
+		// Call the function directly
+		Abuse_Decisions\process_sift_decision_received(
+			null,
+			'block_wo_review_payment_abuse',
+			(string) $this->test_user_id
+		);
+
+		// Action SHOULD have fired because no bypass flag is set
+		self::assertTrue( $action_fired, 'Automated block decision should fire when no bypass flag is set' );
+	}
+
+	/**
+	 * Test the fraudster flag skips ALL automated decisions, including blocks.
+	 *
+	 * A confirmed fraudster has a manual decision on file, so automation must not churn it -
+	 * no re-block, no lesser block, no unblock. Same behavior as the bypass flag.
+	 *
+	 * @return void
+	 */
+	public function test_fraudster_flag_skips_automated_block() {
+		// Set fraudster flag only (no bypass)
+		Abuse_Decisions\apply_fraudster_flag( $this->test_user_id, 'setup' );
+
+		// Track if the block action was fired
+		$action_fired = false;
+		add_action( 'sift_for_woocommerce_block_wo_review_payment_abuse', function() use ( &$action_fired ) {
+			$action_fired = true;
+		} );
+
+		// Enable automated actions
+		update_option( 'wc_sift_for_woocommerce_automated_actions_enabled', 'yes' );
+
+		// Mock user ID translation to return the test user ID directly
+		$test_user_id = $this->test_user_id;
+		add_filter( 'sift_for_woocommerce_pre_sift_decision', function( $user_id ) use ( $test_user_id ) {
+			return $test_user_id;
+		} );
+
+		// Call the function directly
+		Abuse_Decisions\process_sift_decision_received(
+			null,
+			'block_wo_review_payment_abuse',
+			(string) $this->test_user_id
+		);
+
+		// Block should NOT fire - the fraudster flag skips every automated decision.
+		self::assertFalse( $action_fired, 'Fraudster flag should skip an automated block_wo_review decision' );
+	}
+
+	/**
+	 * Test an automated looks_good decision is skipped when the fraudster flag is set.
+	 *
+	 * looks_good fires no automated action today, so the only proof the guard ran is its
+	 * log line. We capture the WC log and check for the skip message - if the guard were
+	 * removed, looks_good would log "not handled" instead and this test would fail.
+	 *
+	 * @return void
+	 */
+	public function test_automated_looks_good_skipped_when_fraudster_flag_set() {
+		// Set fraudster flag
+		Abuse_Decisions\apply_fraudster_flag( $this->test_user_id, 'setup' );
+
+		// Enable automated actions
+		update_option( 'wc_sift_for_woocommerce_automated_actions_enabled', 'yes' );
+
+		// Mock user ID translation to return the test user ID directly
+		$test_user_id = $this->test_user_id;
+		add_filter( 'sift_for_woocommerce_pre_sift_decision', function( $user_id ) use ( $test_user_id ) {
+			return $test_user_id;
+		} );
+
+		// Capture log messages so we can tell the guard ran, not the default "not handled" path.
+		// Priority 1 so we read the message before any other filter on this hook can null it.
+		$messages = array();
+		add_filter( 'woocommerce_logger_log_message', function( $message ) use ( &$messages ) {
+			if ( is_string( $message ) ) {
+				$messages[] = $message;
+			}
+			return $message;
+		}, 1 );
+
+		Abuse_Decisions\process_sift_decision_received(
+			null,
+			'looks_good_payment_abuse',
+			(string) $this->test_user_id
+		);
+
+		$hit_guard = false;
+		foreach ( $messages as $message ) {
+			if ( false !== strpos( $message, 'fraudster flag active' ) ) {
+				$hit_guard = true;
+			}
+		}
+		self::assertTrue( $hit_guard, 'Automated looks_good should be skipped when the fraudster flag is set' );
+	}
+
+	/**
+	 * Test not_likely_fraud decision clears both flags.
+	 *
+	 * @return void
+	 */
+	public function test_not_likely_fraud_decision_clears_both_flags() {
+		// Set up: user has both flags
+		Abuse_Decisions\apply_fraud_review_bypass( $this->test_user_id, 'setup' );
+		Abuse_Decisions\apply_fraudster_flag( $this->test_user_id, 'setup' );
+
+		// Apply not_likely_fraud decision
+		Abuse_Decisions\process_manual_fraud_decision(
+			(string) $this->test_user_id,
+			'not_likely_fraud_payment_abuse',
+			'Test description',
+			'test_analyst'
+		);
+
+		// Both flags should be cleared
+		self::assertFalse( Abuse_Decisions\has_fraud_review_bypass( $this->test_user_id ) );
+		self::assertFalse( Abuse_Decisions\has_fraudster_flag( $this->test_user_id ) );
+	}
+
+	/**
+	 * Test likely_fraud decisions clear both flags.
+	 *
+	 * @return void
+	 */
+	public function test_likely_fraud_decision_clears_both_flags() {
+		// Set up: user has both flags
+		Abuse_Decisions\apply_fraud_review_bypass( $this->test_user_id, 'setup' );
+		Abuse_Decisions\apply_fraudster_flag( $this->test_user_id, 'setup' );
+
+		// Apply likely_fraud decision
+		Abuse_Decisions\process_manual_fraud_decision(
+			(string) $this->test_user_id,
+			'likely_fraud_no_purchases_payment_abuse_1',
+			'Test description',
+			'test_analyst'
+		);
+
+		// Both flags should be cleared
+		self::assertFalse( Abuse_Decisions\has_fraud_review_bypass( $this->test_user_id ) );
+		self::assertFalse( Abuse_Decisions\has_fraudster_flag( $this->test_user_id ) );
+	}
+
+	/**
+	 * Test likely_fraud_keep_purchases decision clears both flags.
+	 *
+	 * @return void
+	 */
+	public function test_likely_fraud_keep_purchases_decision_clears_both_flags() {
+		// Set up: user has both flags
+		Abuse_Decisions\apply_fraud_review_bypass( $this->test_user_id, 'setup' );
+		Abuse_Decisions\apply_fraudster_flag( $this->test_user_id, 'setup' );
+
+		// Apply likely_fraud_keep_purchases decision
+		Abuse_Decisions\process_manual_fraud_decision(
+			(string) $this->test_user_id,
+			'likely_fraud_keep_purchases_payment_abuse',
+			'Test description',
+			'test_analyst'
+		);
+
+		// Both flags should be cleared
+		self::assertFalse( Abuse_Decisions\has_fraud_review_bypass( $this->test_user_id ) );
+		self::assertFalse( Abuse_Decisions\has_fraudster_flag( $this->test_user_id ) );
+	}
+
+	/**
+	 * Test send_decision_to_sift handles a missing API client without fataling.
+	 *
+	 * The manual decision flow fires this filter, and with no Sift client configured it
+	 * must log and return null - not fatal. Guards the namespaced log call and the
+	 * nullable return type.
+	 *
+	 * @return void
+	 */
+	public function test_send_decision_to_sift_returns_null_without_client() {
+		$result = Abuse_Decisions\send_decision_to_sift(
+			(string) $this->test_user_id,
+			'trust_list_payment_abuse',
+			'Test description',
+			'test_analyst'
+		);
+
+		self::assertNull( $result, 'send_decision_to_sift should return null when no Sift client is configured' );
+	}
+}


### PR DESCRIPTION
Part of [FRAUD-126](https://linear.app/a8c/issue/FRAUD-126)
Related to https://github.com/Automattic/woocommerce.com/pull/25903

### Description

On WCCOM a manual fraud decision from an analyst can be immediately undone by an automated Sift webhook. Unblock a user by hand and the next Sift block decision re-blocks them. WCCOM only has a binary block/unblock model, so any manual decision is an authoritative human call that automation should not override.

This adds two user-meta flags so a human decision sticks until another human changes it:

- `sfw_fraud_review_bypass` (trusted user) - automated Sift decisions are skipped entirely.
- `sfw_fraudster_flag` (confirmed fraud) - automated Sift decisions are skipped entirely, so a confirmed fraudster can't be re-blocked, downgraded to a lesser block, or unblocked by automation.

Both flags work the same way: once a human has ruled, automation hands off until another human changes it. This matches the WPCOM pattern (skip automation if either the trusted or fraudster flag is set).

### Changes in this PR

`src/inc/sift-decisions/abuse-decisions.php`:

  * Add the two meta-key constants and six `has`/`apply`/`remove` helper functions (mirrors the WPCOM `Fraud_Risk_Manager` interface).
  * `process_sift_decision_received()` (automated path): if the bypass OR fraudster flag is set, all automated decisions are skipped (matches WPCOM). Both log the skip and return early.
  * `process_manual_fraud_decision()` (manual path): Trust list sets bypass + clears fraudster; Fraud sets fraudster + clears bypass; every other decision clears both. `remove_*` only logs when a flag was actually present, to keep the audit trail clean.
  * Fix a latent fatal in `send_decision_to_sift()` surfaced by the new tests: the no-client branch called `Sift_For_WooCommerce::log()` without the namespace prefix (resolves to a non-existent class) and returned `null` against a non-nullable `: \SiftResponse`. Now `\Sift_For_WooCommerce\Sift_For_WooCommerce::log()` and `: ?\SiftResponse`. Only reachable when the Sift client is unconfigured.

`tests/FraudProtectionFlagsTest.php` - new suite: flag lifecycle, every manual-decision transition, the automation-skip logic (automated decisions skipped when bypass set, and when fraudster set - including blocks), and the no-client `send_decision_to_sift` path.

### Test instructions

Note: the real block/unblock lives in the woocommerce.com sidecar, so locally the `do_action(...)` handlers are called but do nothing. Here we verify the flags get set and the automated decision is skipped (via the log); the end-to-end block/unblock is verified in the WCCOM PR above.

  1. Follow the [readme](https://github.com/woocommerce/sift-for-woocommerce/blob/trunk/README.md) to set up a Local Environment, then enable pretty permalinks (`npx wp-env run cli wp rewrite structure '/%postname%/' && npx wp-env run cli wp rewrite flush`) - with plain permalinks the `/wp-json/` curls below silently return the site homepage instead of JSON.
  2. Open the [Sift console](https://console.sift.com/developer/api-keys?abuse_type=payment_abuse) and make sure you are in **Sandbox Mode** - grab the Sandbox Account ID and an API Key.
  3. Go to `wp-admin/admin.php?page=wc-settings&tab=sift_for_woocommerce`:
    - Fill out the Sandbox Account ID and API Key.
    - Sift Signature / Webhook Key: if empty, add a 40-character hash (`openssl rand -hex 20`).
    - Enable Automated Actions: check the field (enables ALL automated decisions).
  4. Add an API secret for the manual REST endpoint to `.wp-env.override.json` (`bin2hex(random_bytes(48))`):
    - `"config": { "SIFT_FOR_WOOCOMMERCE_API_SECRET": "the long hash" }`
    - or temporarily return true from `src/inc/rest-api.php::verify_authorization`.
  5. Create a test user: `npx wp-env run cli wp user create mytester mytester+1@example.com --password=password123`.
  6. Load the PR.
  7. Gather testing data:

  `{SFW_INSTANCE_URL}` - your local/ngrok/jurassic URL
  `{SIFT_WEBHOOK_KEY}` - the Sift Signature / Webhook Key from step 3
  `{USER_ID}` - the local WP user id of your test user (e.g. `2`)
  `{AUTH_HEADER}` - `hash_hmac('sha256', "/fraud/users/{USER_ID}/decision|" . time(), $api_secret)` as `{$endpoint}|{$time}|{$hash}`. The `time()` is checked against the server clock with a 60s window, so build the header right before you send.

Two notes on the commands below: `wp-env` is shown with `npx` - drop it only if you installed `@wordpress/env` globally. And `wp user meta get` prints the value (exit 0) when a flag is set, but prints nothing and exits 1 when the flag is unset/cleared - that's normal for empty meta, not an error.

---
Test 1: Bypass flag protects a trusted user from an automated block

  1. Apply a manual "Trust list" decision:
```
curl --location 'https://{SFW_INSTANCE_URL}/wp-json/sift-for-woocommerce/v1/fraud/users/{USER_ID}/decision' \
--header 'Authorization: {AUTH_HEADER}' \
--header 'Content-Type: application/json' \
--data '{ "decision_id": "trust_list_payment_abuse", "description": "Manual review - trusted", "analyst": "tx2pnw" }'
```
  2. Verify the bypass flag is set - this prints `1`:
```
npx wp-env run cli wp user meta get {USER_ID} sfw_fraud_review_bypass
```
  3. Send an automated `block_wo_review` webhook for the same user:
```
curl --location --request GET 'https://{SFW_INSTANCE_URL}/wp-json/sift-for-woocommerce/v1/decision' \
--header 'X-Sift-Science-Signature: {SIFT_WEBHOOK_KEY}' \
--header 'Content-Type: application/json' \
--data '{ "decision": { "id": "block_wo_review_payment_abuse" }, "entity": { "id": "{USER_ID}", "type": "user" }, "time": "123456" }'
```
  4. Check the log - `wc_get_logger()` writes to `wp-content/uploads/wc-logs/`, not `debug.log`: `npx wp-env run cli bash -c 'grep -rh "skipped\|Sift Decision Filter" /var/www/html/wp-content/uploads/wc-logs/ | tail'`

**Before:** `Sift Decision Filter Applied` for `block_wo_review_payment_abuse` (block action fires).
**After:** `Automated decision 'block_wo_review_payment_abuse' skipped for user {USER_ID}: fraud review bypass active` - the block action never fires.

---
Test 2: Manual "Fraud" sets the fraudster flag and clears bypass

  1. Apply a manual "Fraud" decision (same curl as Test 1, `"decision_id": "fraud_payment_abuse"`).
  2. Verify - `sfw_fraudster_flag` prints `1`, and `sfw_fraud_review_bypass` prints nothing / exits 1 (it was cleared):
```
npx wp-env run cli wp user meta get {USER_ID} sfw_fraudster_flag
npx wp-env run cli wp user meta get {USER_ID} sfw_fraud_review_bypass
```
  3. Send an automated `block_wo_review` webhook (Test 1 curl). The fraudster flag also skips all automation, so the log shows `Automated decision 'block_wo_review_payment_abuse' skipped for user {USER_ID}: fraudster flag active` and the block action never fires.

---
Test 3: Manual decision no longer fatals without a Sift client

With the Sift API key/account ID blank in settings, apply any manual decision (Test 1 curl).
**Before:** fatal `Class "Sift_For_WooCommerce\Abuse_Decisions\Sift_For_WooCommerce" not found`.
**After:** request succeeds; log shows `Failed to get the Sift API client.` and the flags/last-decision meta still update.

#### Automated

```
npm test -- --filter=Fraud_Protection_Flags_Test
```
13 tests, 23 assertions. Full suite stays green (202 tests).


